### PR TITLE
Implement l1 norm based full ZNCC algorithm

### DIFF
--- a/modules/model_fit_algo/lasseck2013/model_fit_algo.py
+++ b/modules/model_fit_algo/lasseck2013/model_fit_algo.py
@@ -54,13 +54,19 @@ def crossCorrMatchTemplate(spectrogram, template):
 
     output = np.zeros((o_max, i_max), dtype="float32")
 
+    T = (template - np.mean(template)) / np.linalg.norm(template, ord=1)
+
     for o_idx in range(o_max):
         for i_idx in range(i_max):
             o_up_bound = o_idx + template.shape[0]
             i_up_bound = i_idx + template.shape[1]
-            output[o_idx, i_idx] = np.sum(
-                spectrogram[o_idx:o_up_bound, i_idx:i_up_bound] * template
+
+            image_slice = spectrogram[o_idx:o_up_bound, i_idx:i_up_bound]
+            I = (image_slice - np.mean(image_slice)) / np.linalg.norm(
+                image_slice, ord=1
             )
+
+            output[o_idx, i_idx] = np.sum(I * T)
 
     return np.nan_to_num(output)
 


### PR DESCRIPTION
The `np.linalg.norm(..., ord=2)` is typically used for the ZNCC algorithm, however, it is very slow which is why we simply took an approximation where the spectrogram and template fed to the matching function are normalized beforehand. The approximate ZNCC doesn't behave properly.

This version, with `ord=1`, behaves similarly to the full ZNCC algorithm but is only ~5 times slower than the approximate one. As opposed to ~400,000 times slower for the full ZNCC (`ord=2`).