### PR TITLE
Implement the actual ZNCC with standard deviation not `ord=2` norm

### DIFF
--- a/modules/image_utils.py
+++ b/modules/image_utils.py
@@ -16,7 +16,7 @@ def apply_gaussian_filter(spec, sigma):
     return gaussian_filter(spec, sigma=float(sigma))
 
 
-def generate_raw_spectrogram(spectrogram, spectrogram_mean, spectrogram_l2_norm):
+def generate_raw_spectrogram(spectrogram, spectrogram_mean, spectrogram_std):
     """Given a normalized spectrogram
 
     Recreate the raw spectrogram
@@ -24,16 +24,16 @@ def generate_raw_spectrogram(spectrogram, spectrogram_mean, spectrogram_l2_norm)
     Args:
         spectrogram: The normalized spectrogram
         spectrogram_mean: The np.mean(_) of the raw spectrogram
-        spectrogram_l2_norm: The np.linalg.norm(_, ord=2) of the original spectrogram
+        spectrogram_std: The np.std(_) of the raw spectrogram
     """
 
     # Reverse the z-score normalization
-    raw_spectrogram = (spectrogram * spectrogram_l2_norm) + spectrogram_mean
+    raw_spectrogram = (spectrogram * spectrogram_std) + spectrogram_mean
     return raw_spectrogram.astype("float32", casting="same_kind")
 
 
 def generate_raw_blurred_spectrogram(
-    spectrogram, spectrogram_mean, spectrogram_l2_norm, gaussian_blur_sigma
+    spectrogram, spectrogram_mean, spectrogram_std, gaussian_blur_sigma
 ):
     """Given a normalized spectrogram
 
@@ -42,12 +42,12 @@ def generate_raw_blurred_spectrogram(
     Args:
         spectrogram: The normalized spectrogram
         spectrogram_mean: The np.mean(_) of the raw spectrogram
-        spectrogram_l2_norm: The np.linalg.norm(_, ord=2) of the original spectrogram
+        spectrogram_std: The np.std(_) of the raw spectrogram
         gaussian_blur_sigma: The gaussian blur amount
     """
 
     # Reverse the z-score normalization
-    raw_spectrogram = (spectrogram * spectrogram_l2_norm) + spectrogram_mean
+    raw_spectrogram = (spectrogram * spectrogram_std) + spectrogram_mean
     return apply_gaussian_filter(raw_spectrogram, gaussian_blur_sigma).astype(
         "float32", casting="same_kind"
     )

--- a/modules/predict_algo/lasseck2013/predict_algo.py
+++ b/modules/predict_algo/lasseck2013/predict_algo.py
@@ -75,14 +75,14 @@ def run_stats(predict_idx, train_labels_df, config):
     )
     from model_fit_algo import get_file_stats, get_file_file_stats
 
-    df_predict, spec_predict, spec_mean_predict, spec_l2_norm_predict, row_predict = get_file_stats(
+    df_predict, spec_predict, spec_mean_predict, spec_std_predict, row_predict = get_file_stats(
         predict_idx, config
     )
     match_stats_dict = get_file_file_stats(
         df_predict,
         spec_predict,
         spec_mean_predict,
-        spec_l2_norm_predict,
+        spec_std_predict,
         train_labels_df,
         config,
     )

--- a/modules/spect_gen_algo/lasseck2013/spect_gen_algo.py
+++ b/modules/spect_gen_algo/lasseck2013/spect_gen_algo.py
@@ -239,10 +239,10 @@ def preprocess(label, config):
         spectrogram, config["spect_gen"].getfloat("decibel_threshold")
     )
 
-    # Z-score normalization, need mean and l2 norm later
-    spectrogram_mean = spectrogram.mean()
-    spectrogram_l2_norm = np.linalg.norm(spectrogram, ord=2)
-    spectrogram = (spectrogram - spectrogram_mean) / spectrogram_l2_norm
+    # Z-score normalization, need mean and std later
+    spectrogram_mean = np.mean(spectrogram)
+    spectrogram_std = np.std(spectrogram)
+    spectrogram = (spectrogram - spectrogram_mean) / spectrogram_std
 
     # # Scaled Median Column/Row Filters
     # -> this filter stinks after z-score normalization
@@ -300,10 +300,10 @@ def preprocess(label, config):
     # Write to DB, if defined:
     if config["general"].getboolean("db_rw"):
         write_spectrogram(
-            label, bboxes_df, spectrogram, spectrogram_mean, spectrogram_l2_norm, config
+            label, bboxes_df, spectrogram, spectrogram_mean, spectrogram_std, config
         )
     else:
-        return bboxes_df, spectrogram, spectrogram_mean, spectrogram_l2_norm
+        return bboxes_df, spectrogram, spectrogram_mean, spectrogram_std
 
 
 def spect_gen_algo(config):

--- a/modules/view.py
+++ b/modules/view.py
@@ -150,15 +150,13 @@ def view(label, image, seg_only, config):
 
     # Get the data, from the database or recreate
     init_client(config)
-    df, spectrogram, spectrogram_mean, spectrogram_l2_norm = read_spectrogram(
-        label, config
-    )
+    df, spectrogram, spectrogram_mean, spectrogram_std = read_spectrogram(label, config)
     close_client()
 
     spectrogram = generate_raw_blurred_spectrogram(
         spectrogram,
         spectrogram_mean,
-        spectrogram_l2_norm,
+        spectrogram_std,
         config["model_fit"]["gaussian_filter_sigma"],
     )
 


### PR DESCRIPTION
In #61, I wanted to implement an approximation to the following equation:

![original](https://user-images.githubusercontent.com/3086255/51703902-9fc57300-1fe5-11e9-8126-d06f4e062190.gif)

The approximation was that the normalization procedure happened outside of the cross-correlation generation. Unfortunately, this approximation doesn't match the behavior we need from a cross-correlation algorithm. In #69, we moved normalization back into the cross-correlation algorithm but using `np.linalg.norm(..., ord=1)` (`ord=2` is extremely slow because it needs to solve the eigenvalue problem). The `ord=1` version gives us the proper behavior, but isn't ZNCC! The correct mathematical equation for ZNCC is shown below:

![correct](https://user-images.githubusercontent.com/3086255/51703997-eadf8600-1fe5-11e9-8e68-218978ba4b3f.gif)

This PR is the correct implementation of ZNCC.