### PR TITLE
Write a CSV file during model fit

### DIFF
--- a/modules/model_fit.py
+++ b/modules/model_fit.py
@@ -2,7 +2,7 @@ import sys
 from modules.db_utils import write_ini_section
 
 
-def model_fit(config, rerun_statistics):
+def model_fit(config):
     """Fit a model
 
     Given a directory and method (from config), fit a model against the
@@ -13,7 +13,6 @@ def model_fit(config, rerun_statistics):
 
     Args:
         config: The parsed ini file for this run
-        rerun_statistics: Force recalculation of model_fit statistics
 
     Returns:
         Something or possibly writes to MongoDB?
@@ -31,4 +30,4 @@ def model_fit(config, rerun_statistics):
     if config["general"].getboolean("db_rw"):
         write_ini_section(config, "model_fit")
 
-    model_fit_algo(config, rerun_statistics)
+    model_fit_algo(config)

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -77,16 +77,16 @@ def return_cpu_count(config):
     return nprocs
 
 
-def generate_config(f_default, f_override):
+def generate_config(f_default, arguments):
     """Generate the configuration
 
     Simply return a ConfigParser for opensoundscape. We have a default config in
-    `config/` as well as a potential override file. Access elements via
+    `config/` as well as a potential override file (arguments["--ini"]). Access elements via
     `config[<section>].get{float,boolean,int}('key')`.
 
     Args:
         f_default: The default config `config/opensoundscape.ini`
-        f_override: The override config `opensoundscape.ini`
+        arguments: The docopt arguments to store
 
     Returns:
         A ConfigParser instance
@@ -96,13 +96,14 @@ def generate_config(f_default, f_override):
     """
     opensoundscape_dir = sys.path[0]
     f_default = join(opensoundscape_dir, f_default)
+    f_override = arguments["--ini"]
 
     if not isfile(f_default):
         raise FileNotFoundError(f"{f_default} doesn't exist!")
     if not isfile(f_override):
         raise FileNotFoundError(f"{f_override} doesn't exist!")
 
-    config = ConfigParser()
+    config = ConfigParser(allow_no_value=True)
     config.read(f_default)
 
     override_config = ConfigParser()
@@ -113,6 +114,14 @@ def generate_config(f_default, f_override):
     config.read(f_override)
 
     config_checks(config)
+
+    # Finally, store any command line options so we only need to pass config
+    config["docopt"] = {}
+    config["docopt"]["label"] = arguments["<label>"]
+    config["docopt"]["image"] = arguments["<image>"]
+    config["docopt"]["print_segments"] = str(arguments["--segments"]).lower()
+    config["docopt"]["rerun_statistics"] = str(arguments["--rerun_statistics"]).lower()
+    config["docopt"]["csv_file"] = arguments["<csv_file>"]
 
     return config
 

--- a/modules/view.py
+++ b/modules/view.py
@@ -22,10 +22,10 @@ def show_or_write(image):
         Nothing
     """
 
-    if len(image) == 0:
-        plt.show()
-    else:
+    if image:
         plt.savefig(image)
+    else:
+        plt.show()
 
 
 def extract_segments(spec, df):
@@ -129,16 +129,13 @@ def gen_segs(spec, df, image):
     show_or_write(image)
 
 
-def view(label, image, seg_only, config):
+def view(config):
     """View a spectrogram
 
     This is a super function which provides all of the functionality to
     view a spectrogram, either from the database itself or recreated
 
     Args:
-        label: The label for the file
-        image: If not '', write image to a file named this
-        seg_only: View segments only
         config: The parsed ini file for this particular run
 
     Returns:
@@ -147,6 +144,11 @@ def view(label, image, seg_only, config):
     Raises:
         FileNotFoundError: If the wavfile doesn't exist, it can't be processed
     """
+
+    # Need some command line arguments from config
+    label = config["docopt"]["label"]
+    image = config["docopt"]["image"]
+    seg_only = config["docopt"].getboolean("print_segments")
 
     # Get the data, from the database or recreate
     init_client(config)

--- a/opensoundscape.py
+++ b/opensoundscape.py
@@ -5,13 +5,14 @@ Usage:
     opensoundscape.py init [-i <ini>]
     opensoundscape.py spect_gen [-i <ini>]
     opensoundscape.py view <label> [<image>] [-i <ini>] [-s]
-    opensoundscape.py model_fit [-i <ini>] [-r]
+    opensoundscape.py model_fit [-i <ini>] [-r] [<csv_file>]
     opensoundscape.py predict [-i <ini>]
 
 Positional Arguments:
     <label>                 The label you would like to view, must be in the configs
                                 defined as `data_dir`
     <image>                 An image file to write, e.g. 'image.png'
+    <csv_file>              Store model_fit metrics in a CSV file
 
 Options:
     -h --help               Print this screen and exit
@@ -34,7 +35,7 @@ from modules.init import init
 arguments = docopt(__doc__, version="opensoundscape.py version 0.0.1")
 
 # Get the default config variables
-config = generate_config("config/opensoundscape.ini", arguments["--ini"])
+config = generate_config("config/opensoundscape.ini", arguments)
 
 # Initialize empty string for arguments['<image>'] (not supported by docopt)
 if not arguments["<image>"]:
@@ -47,11 +48,11 @@ if arguments["spect_gen"]:
 elif arguments["view"]:
     # Preprocess the file with the defaults
     # -> optionally write image to a file
-    view(arguments["<label>"], arguments["<image>"], arguments["--segments"], config)
+    view(config)
 
 elif arguments["model_fit"]:
     # Using defined algorithm, create model
-    model_fit(config, arguments["--rerun_statistics"])
+    model_fit(config)
 
 elif arguments["predict"]:
     # Make a prediction based on a model


### PR DESCRIPTION
This PR addresses the other half of #19. Write standard out as well as an optional CSV file which is specified in the command line arguments.

e.g. `opensoundscape.py model_fit <file>.csv`