### PR TITLE
Replace zeroes in decible_filter with np.nan

### DIFF
--- a/opensoundscape/spect_gen/spect_gen_algo/template_matching/spect_gen_algo.py
+++ b/opensoundscape/spect_gen/spect_gen_algo/template_matching/spect_gen_algo.py
@@ -54,7 +54,7 @@ def generate_segments_from_binary_spectrogram(binary_spec, buffer):
     return df
 
 
-def decible_filter(spectrogram, db_cutoff):
+def decibel_filter(spectrogram, db_cutoff):
     """Filter spectrogram with a minimum decibel cutoff
 
     Given a spectrogram, set anything below the cutoff to the cutoff
@@ -233,7 +233,7 @@ def return_spectrogram(label, config):
     )
 
     # Decibel filter
-    spectrogram = decible_filter(
+    spectrogram = decibel_filter(
         spectrogram, config["spect_gen"].getfloat("decibel_threshold")
     )
 

--- a/opensoundscape/spect_gen/spect_gen_algo/template_matching/spect_gen_algo.py
+++ b/opensoundscape/spect_gen/spect_gen_algo/template_matching/spect_gen_algo.py
@@ -67,9 +67,11 @@ def decible_filter(spectrogram, db_cutoff):
         new_spectrogram: The output spectogram in V**2
     """
 
-    inDb = 10.0 * np.log10(spectrogram)
+    remove_zeros = np.copy(spectrogram)
+    remove_zeros[remove_zeros == 0.0] = np.nan
+    inDb = 10.0 * np.log10(remove_zeros)
     inDb[inDb <= db_cutoff] = db_cutoff
-    return 10.0 ** (inDb / 10.0)
+    return np.nan_to_num(10.0 ** (inDb / 10.0))
 
 
 def low_values_filter(spectrogram, percent_threshold):


### PR DESCRIPTION
Dealing with preprocessed sound files can lead to many zeroes in the spectrogram. When we do the decibel filter, replace them with `np.nan` (ignoring them) and `np.nan_to_num` the filtered result.