### PR TITLE
Ensure spectrogram is in dense representation

### DIFF
--- a/opensoundscape/utils/db_utils.py
+++ b/opensoundscape/utils/db_utils.py
@@ -289,8 +289,11 @@ def cursor_item_to_data(item, config):
     spec = pickle.loads(spec_bytes)
     mean = pickle.loads(mean_bytes)
     std = pickle.loads(std_bytes)
-    if config["general"].getboolean("db_sparse"):
+
+    # Ensure spectrogram is in dense representation
+    if hasattr(spec, "todense"):
         spec = spec.todense()
+
     return df, spec, mean, std
 
 


### PR DESCRIPTION
If spectrogram has a `todense()` method, i.e. it is stored as a sparse matrix, return the spectrogram in dense representation instead. 

Previous code only converted the spectrogram to dense representation if `sparse_db = True` in the config file. However, OpenSoundscape may access sparse spectrogram databases without our current analysis/config file specifying `sparse_db = True`. Specifically, we ran into this bug by creating sparsely-stored templates using `opso_raven_selections_to_template_db`, but later using this template database in a non-sparse model fitting analysis.