### PR TITLE
Use immutable class to store samples

### DIFF
--- a/opensoundscape/audio.py
+++ b/opensoundscape/audio.py
@@ -6,6 +6,36 @@ import pathlib
 import io
 import librosa
 import soundfile
+import numpy as np
+
+
+class Samples:
+    """ Immutable container for audio samples
+
+    This immutable class contains the samples and sample_rate for a particular
+    audio file
+
+    Args:
+        samples: np.ndarray [shape (n,)], the audio samples
+        sample_rate: int, the sampling rate for the audio samples
+    """
+
+    __slots__ = ("samples", "sample_rate")
+
+    def __init__(self, samples, sample_rate):
+        if not isinstance(samples, np.ndarray):
+            raise TypeError("Samples is not an np.ndarray?")
+        if samples.ndim != 1:
+            raise AttributeError("Samples should be sampled in mono channel")
+
+        super(Samples, self).__setattr__("samples", samples)
+        super(Samples, self).__setattr__("sample_rate", sample_rate)
+
+    def __setattr__(self, name, value):
+        raise AttributeError("Samples is an immutable container")
+
+    def __repr__(self):
+        return f"<Samples(samples={self.samples.shape}, sample_rate={self.sample_rate})>"
 
 
 class OpsoLoadAudioInputError(Exception):
@@ -22,7 +52,7 @@ class OpsoLoadAudioInputTooLong(Exception):
     pass
 
 
-def load(audio, sample_rate=22050, max_duration=600, resample_type="kaiser_fast"):
+def load_samples(audio, sample_rate=22050, max_duration=600, resample_type="kaiser_fast"):
     """ Load audio in various formats and generate a spectrogram
 
     Deal with the various possible input types to load an audio
@@ -35,7 +65,7 @@ def load(audio, sample_rate=22050, max_duration=600, resample_type="kaiser_fast"
                        None is no maximum (default: 600 seconds)
 
     Returns:
-        samples: mono samples, np.ndarray [shape=(n,)]
+        Samples: class, attributes samples and sample_rate
     """
 
     # Deal with a string/path-like object
@@ -67,7 +97,7 @@ def load(audio, sample_rate=22050, max_duration=600, resample_type="kaiser_fast"
             )
 
         samples, _ = librosa.load(
-            path, sr=sample_rate, res_type=resample_type, mono=True
+            str(path.resolve()), sr=sample_rate, res_type=resample_type, mono=True
         )
 
     else:
@@ -78,4 +108,4 @@ def load(audio, sample_rate=22050, max_duration=600, resample_type="kaiser_fast"
         if samples.ndim > 1:
             samples = librosa.to_mono(samples)
 
-    return samples
+    return Samples(samples, sample_rate)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -34,38 +34,38 @@ def veryshort_wav_bytesio(veryshort_wav_str):
 
 
 def test_load_veryshort_wav_str_44100(veryshort_wav_str):
-    samples = load(veryshort_wav_str, sample_rate=44100)
-    assert samples.shape == (6266,)
+    s = load_samples(veryshort_wav_str, sample_rate=44100)
+    assert s.samples.shape == (6266,)
 
 
 def test_load_veryshort_wav_str(veryshort_wav_str):
-    samples = load(veryshort_wav_str)
-    assert samples.shape == (3133,)
+    s = load_samples(veryshort_wav_str)
+    assert s.samples.shape == (3133,)
 
 
 def test_load_veryshort_wav_pathlib(veryshort_wav_pathlib):
-    samples = load(veryshort_wav_pathlib)
-    assert samples.shape == (3133,)
+    s = load_samples(veryshort_wav_pathlib)
+    assert s.samples.shape == (3133,)
 
 
 def test_load_veryshort_wav_bytesio(veryshort_wav_bytesio):
-    samples = load(veryshort_wav_bytesio)
-    assert samples.shape == (3133,)
+    s = load_samples(veryshort_wav_bytesio)
+    assert s.samples.shape == (3133,)
 
 
 def test_load_pathlib_and_bytesio_are_almost_equal(
     veryshort_wav_pathlib, veryshort_wav_bytesio
 ):
-    samples_pathlib = load(veryshort_wav_pathlib)
-    samples_bytesio = load(veryshort_wav_bytesio)
-    np.testing.assert_allclose(samples_pathlib, samples_bytesio, atol=1e-7)
+    s_pathlib = load_samples(veryshort_wav_pathlib)
+    s_bytesio = load_samples(veryshort_wav_bytesio)
+    np.testing.assert_allclose(s_pathlib.samples, s_bytesio.samples, atol=1e-7)
 
 
 def test_load_silence_10s_mp3_str_asserts_too_long(silence_10s_mp3_str):
     with pytest.raises(OpsoLoadAudioInputTooLong):
-        load(silence_10s_mp3_str, max_duration=5)
+        load_samples(silence_10s_mp3_str, max_duration=5)
 
 
 def test_load_not_a_file_asserts_not_a_file(not_a_file_str):
     with pytest.raises(FileNotFoundError):
-        load(not_a_file_str)
+        load_samples(not_a_file_str)


### PR DESCRIPTION
- Use an immutable class to store `Samples`
- Change `load` to `load_samples`
- Fix tests
- Fix issue on Tessa's computer with `librosa(<pathlib.Path>)`, use `str`