### PR TITLE
Add the ability to split audio files via PyTorch

### DIFF
--- a/opensoundscape/console.py
+++ b/opensoundscape/console.py
@@ -9,8 +9,10 @@ from opensoundscape import __version__ as opensoundscape_version
 import opensoundscape.raven as raven
 from opensoundscape.completions import COMPLETIONS
 import opensoundscape.console_checks as checks
-from opensoundscape.dataset import Splitter
+from opensoundscape.datasets import Splitter
 from torch.utils.data import DataLoader
+from pathlib import Path
+from itertools import chain
 
 
 OPSO_DOCOPT = """ opensoundscape.py -- Opensoundscape
@@ -21,14 +23,14 @@ Usage:
     opensoundscape raven_lowercase_annotations <directory>
     opensoundscape raven_generate_class_corrections <directory> <output.csv>
     opensoundscape raven_query_annotations <directory> <class>
-    opensoundscape split_audio (-i <directory>) (-o <directory>) (-d <duration>) (-p <overlap>) [-s <segments.csv>]
-        [-a -l <labels.csv>] [-n <cores>] [-b <batch_size>]
+    opensoundscape split_audio (-i <directory>) (-o <directory>) (-d <duration>) (-p <overlap>)
+        [-a -l <labels.csv>] [-n <cores>] [-b <batch_size>] [-s <segments.csv>]
 
 Options:
     -h --help                           Print this screen and exit
     -v --version                        Print the version of opensoundscape.py
-    -i --input_directory                The input directory for the analysis
-    -o --output_directory               The output directory for the analysis
+    -i --input_directory <directory>    The input directory for the analysis
+    -o --output_directory <directory>   The output directory for the analysis
     -d --duration <duration>            The segment duration in seconds
     -p --overlap <overlap>              The segment overlap in seconds
     -a --annotations                    Search for Raven annotation files
@@ -95,7 +97,7 @@ def entrypoint():
         if segments.exists():
             segments.rename(segments.with_suffix(".csv.bak"))
 
-        wavs = input_p.rglob("**/*.WAV") + input_p.rglob("**/*.wav")
+        wavs = chain(input_p.rglob("**/*.WAV"), input_p.rglob("**/*.wav"))
 
         dataset = Splitter(
             wavs,

--- a/opensoundscape/console.py
+++ b/opensoundscape/console.py
@@ -8,6 +8,7 @@ import opensoundscape as opso
 from opensoundscape import __version__ as opensoundscape_version
 import opensoundscape.raven as raven
 from opensoundscape.completions import COMPLETIONS
+import opensoundscape.console_checks as checks
 
 
 OPSO_DOCOPT = """ opensoundscape.py -- Opensoundscape
@@ -18,10 +19,20 @@ Usage:
     opensoundscape raven_lowercase_annotations <directory>
     opensoundscape raven_generate_class_corrections <directory> <output.csv>
     opensoundscape raven_query_annotations <directory> <class>
+    opensoundscape split_audio (-i <directory>) (-o <directory>) (-d <duration>) (-p <overlap>)
+        [-a -l <labels.csv>] [-n <cores>] [-b <batch_size>]
 
 Options:
     -h --help                           Print this screen and exit
     -v --version                        Print the version of opensoundscape.py
+    -i --input_directory                The input directory for the analysis
+    -o --output_directory               The output directory for the analysis
+    -d --duration <duration>            The segment duration in seconds
+    -p --overlap <overlap>              The segment overlap in seconds
+    -a --annotations                    Search for Raven annotation files
+    -l --labels <labels.csv>            A CSV file with corrections to labels in Raven annotations files
+    -n --num_cores <number>             The number of cores to use for the analysis [default: 1]
+    -b --batch_size <number>            The batch_size for the analysis [default: 1]
 
 Positional Arguments:
     <directory>                         A path to a directory
@@ -29,10 +40,14 @@ Positional Arguments:
     <class>                             The class name for the analysis
 
 Descriptions:
-    completions                         Generate bash completions `opensoundscape completions > ~/.local/share/bash-completion/completions/opensoundscape`
+    completions                         Generate bash completions
+                                        `opensoundscape completions > ~/.local/share/bash-completion/completions/opensoundscape`
     raven_annotation_check              Given a directory of Raven annotation files, check that a class is specified
-    raven_generate_class_corrections    Given a directory of Raven annotation files, generate a CSV file to check classes and correct any issues
+    raven_generate_class_corrections    Given a directory of Raven annotation files,
+                                        generate a CSV file to check classes and correct any issues
     raven_query_annotations             Given a directory of Raven annotation files, search for rows matching a specific class
+    split_audio                         Given a directory of WAV files, optional Raven annotation files,
+                                            optional label corrects, split then into segments of a given duration and overlap
 """
 
 
@@ -59,6 +74,17 @@ def entrypoint():
 
     elif args["raven_query_annotations"]:
         raven.query_annotations(args["<directory>"], args["<class>"])
+
+    elif args["split_audio"]:
+        args["--duration"] = checks.positive_integer(args, "--duration")
+        args["--overlap"] = checks.positive_integer(args, "--overlap")
+        args["--batch_size"] = checks.positive_integer_with_default(args, "--batch_size")
+        args["--num_cores"] = checks.positive_integer_with_default(args, "--num_cores")
+
+        input_p = checks.directory_exists(args, "--input_directory")
+        output_p = checks.directory_exists(args, "--output_directory")
+
+        # HERE
 
     else:
         raise NotImplementedError(

--- a/opensoundscape/console_checks.py
+++ b/opensoundscape/console_checks.py
@@ -11,7 +11,9 @@ def positive_integer(args, parameter):
             raise ValueError
         return r
     except ValueError:
-        exit(f"Error: `{parameter}` should be a positive whole number! Got `{args[parameter]}`")
+        exit(
+            f"Error: `{parameter}` should be a positive whole number! Got `{args[parameter]}`"
+        )
 
 
 def positive_integer_with_default(args, parameter, default=1):
@@ -20,10 +22,15 @@ def positive_integer_with_default(args, parameter, default=1):
     else:
         return default
 
+
 def directory_exists(args, parameter):
     p = Path(args["--parameter"])
     if not p.exists():
-        raise FileNotFoundError(f"The directory given to `{parameter}` does not exist, got `{args['--parameter']}`")
+        raise FileNotFoundError(
+            f"The directory given to `{parameter}` does not exist, got `{args['--parameter']}`"
+        )
     if not p.is_dir():
-        raise NotADirectoryError(f"The directory given to `{parameter}` should be a directory but I found a file, got `{args['--parameter']}`")
+        raise NotADirectoryError(
+            f"The directory given to `{parameter}` should be a directory but I found a file, got `{args['--parameter']}`"
+        )
     return p

--- a/opensoundscape/console_checks.py
+++ b/opensoundscape/console_checks.py
@@ -24,13 +24,13 @@ def positive_integer_with_default(args, parameter, default=1):
 
 
 def directory_exists(args, parameter):
-    p = Path(args["--parameter"])
+    p = Path(args[parameter])
     if not p.exists():
         raise FileNotFoundError(
-            f"The directory given to `{parameter}` does not exist, got `{args['--parameter']}`"
+            f"The directory given to `{parameter}` does not exist, got `{args[parameter]}`"
         )
     if not p.is_dir():
         raise NotADirectoryError(
-            f"The directory given to `{parameter}` should be a directory but I found a file, got `{args['--parameter']}`"
+            f"The directory given to `{parameter}` should be a directory but I found a file, got `{args[parameter]}`"
         )
     return p

--- a/opensoundscape/console_checks.py
+++ b/opensoundscape/console_checks.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+""" Utilities related to console checks on docopt args
+"""
+from pathlib import Path
+
+
+def positive_integer(args, parameter):
+    try:
+        r = int(args[parameter])
+        if r <= 0:
+            raise ValueError
+        return r
+    except ValueError:
+        exit(f"Error: `{parameter}` should be a positive whole number! Got `{args[parameter]}`")
+
+
+def positive_integer_with_default(args, parameter, default=1):
+    if args[parameter]:
+        return positive_integer(args, parameter)
+    else:
+        return default
+
+def directory_exists(args, parameter):
+    p = Path(args["--parameter"])
+    if not p.exists():
+        raise FileNotFoundError(f"The directory given to `{parameter}` does not exist, got `{args['--parameter']}`")
+    if not p.is_dir():
+        raise NotADirectoryError(f"The directory given to `{parameter}` should be a directory but I found a file, got `{args['--parameter']}`")
+    return p

--- a/opensoundscape/datasets.py
+++ b/opensoundscape/datasets.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+import torch
+import pandas as pd
+import numpy as np
+from math import ceil, floor
+from hashlib import md5
+from librosa.output import write_wav
+from librosa.core import load, get_duration
+from sys import stderr
+from Pathlib import Path
+
+
+def get_segment(clip_begin, clip_end, samples, sr):
+    """ Extract a segment from the samples
+
+    Inputs:
+        clip_begin:         Beginning of the clip (units: seconds)
+        clip_end:           End of the clip (units: seconds)
+        samples:            The samples to extract the clip from
+        sr:                 The sample rate for the given samples
+
+    Outputs:
+        segment_samples:    The segment extracted from the samples
+        begin:              The index for clip_begin from samples
+        end:                The index for clip_end from samples
+    """
+    begin = floor(clip_begin * sr)
+    end = ceil(clip_end * sr)
+    return samples[begin:end], begin, end
+
+
+def get_md5_digest(input_string):
+    """ Generate MD5 sum for a string
+
+    Inputs:
+        input_string: An input string
+
+    Outputs:
+        output: A string containing the md5 hash of input string
+    """
+    with md5() as obj:
+        obj.update(input_string.encode("utf-8"))
+        return obj.hexdigest()
+
+
+def annotations_with_overlaps_with_clip(df, begin, end):
+    """ Determine if any rows overlap with current segment
+
+    Inputs:
+        df:     A dataframe containing a Raven annotation file
+        begin:  The begin time of the current segment (unit: seconds)
+        end:    The end time of the current segment (unit: seconds)
+
+    Output:
+        sub_df: A dataframe of annotations which overlap with the begin/end times
+    """
+    return df[
+        ((df["begin time (s)"] >= begin) & (df["begin time (s)"] < end))
+        | ((df["end time (s)"] > begin) & (df["end time (s)"] <= end))
+    ]
+
+
+
+# TODO:
+# - Should be able to process WAV or MP3 files?
+# - Should use the opensoundscape.audio.Audio object, need to input and forward audio configuration
+class Splitter(torch.utils.data.Dataset):
+    """ A PyTorch Dataset for splitting a WAV files
+
+    Inputs:
+        wavs:               A list of WAV files to split
+        annotations:        Should we search for corresponding annotations files? (default: False)
+        labels:             Specify a correction labels CSV file w/ column headers "raw" and "corrected" (default: None)
+        overlap:            How much overlap should there be between samples (units: seconds, default: 1)
+        duration:           How long should each segment be? (units: seconds, default: 5)
+        output_directory    Where should segments be written? (default: segments/)
+
+    Effects:
+        - Segments will be written to the output_directory
+
+    Outputs:
+        output: A list of CSV rows containing the source audio, segment begin
+                time (seconds), segment end time (seconds), segment audio, and present
+                classes separated by '|' if annotations were requested
+    """
+    def __init__(
+        self,
+        wavs,
+        annotations=False,
+        labels=None,
+        overlap=1,
+        duration=5,
+        output_directory="segments",
+    ):
+        self.wavs = list(wavs)
+
+        self.annotations = annotations
+        self.labels = labels
+        if self.labels:
+            self.labels_df = pd.read_csv(labels)
+
+        self.overlap = overlap
+        self.duration = duration
+        self.output_directory = output_directory
+
+    def __len__(self):
+        return len(self.wavs)
+
+    def __getitem__(self, item_idx):
+        wav = self.wavs[item_idx]
+        annotation_prefix = self.wavs[item_idx].stem.split(".")[0]
+
+        if self.annotations:
+            annotation_file = Path(
+                f"{wav.parent}/{annotation_prefix}.Table.1.selections.txt.lower"
+            )
+            if not annotation_file.is_file():
+                sys.stderr.write(f"Warning: Found no Raven annotations for {wav}\n")
+                return {"data": []}
+
+        wav_samples, wav_sample_rate = load(wav)
+        wav_duration = get_duration(wav_samples, sr=wav_sample_rate)
+        wav_times = np.arange(0.0, wav_duration, wav_duration / len(wav_samples))
+
+        if self.annotations:
+            annotation_df = pd.read_csv(annotation_file, sep="\t").sort_values(
+                by=["begin time (s)"]
+            )
+
+        if self.labels:
+            annotation_df["class"] = annotation_df["class"].fillna("unknown")
+            annotation_df["class"] = annotation_df["class"].apply(
+                lambda cls: self.labels_df[self.labels_df["raw"] == cls]["corrected"].values[
+                    0
+                ]
+            )
+
+        num_segments = ceil(
+            (wav_duration - self.overlap) / (self.duration - self.overlap)
+        )
+
+        outputs = []
+        for idx in range(num_segments):
+            if idx == num_segments - 1:
+                end = wav_duration
+                begin = end - self.duration
+            else:
+                begin = self.duration * idx - self.overlap * idx
+                end = begin + self.duration
+
+            if self.annotations:
+                overlaps = annotations_with_overlaps_with_clip(
+                    annotation_df, begin, end
+                )
+
+            unique_string = f"{wav}-{begin}-{end}"
+            destination = f"{self.output_directory}/{get_md5_digest(unique_string)}"
+
+            if self.annotations:
+                if overlaps.shape[0] > 0:
+                    segment_samples, segment_sample_begin, segment_sample_end = get_segment(
+                        begin, end, wav_samples, wav_sample_rate
+                    )
+                    write_wav(f"{destination}.WAV", segment_samples, wav_sample_rate)
+
+                    if idx == num_segments - 1:
+                        to_append = f"{wav},{annotation_file},{wav_times[segment_sample_begin]},{wav_times[-1]},{destination}.WAV"
+                    else:
+                        to_append = f"{wav},{annotation_file},{wav_times[segment_sample_begin]},{wav_times[segment_sample_end]},{destination}.WAV"
+                    to_append += f",{'|'.join(overlaps['class'].unique())}"
+
+                    outputs.append(to_append)
+            else:
+                segment_samples, segment_sample_begin, segment_sample_end = get_segment(
+                    begin, end, wav_samples, wav_sample_rate
+                )
+                write_wav(f"{destination}.WAV", segment_samples, wav_sample_rate)
+
+                if idx == num_segments - 1:
+                    to_append = f"{wav},{wav_times[segment_sample_begin]},{wav_times[-1]},{destination}.WAV"
+                else:
+                    to_append = f"{wav},{wav_times[segment_sample_begin]},{wav_times[segment_sample_end]},{destination}.WAV"
+
+                outputs.append(to_append)
+
+        return {"data": outputs}
+
+    @classmethod
+    def collate_fn(batch):
+        return chain.from_iterable([x["data"] for x in batch])

--- a/opensoundscape/datasets.py
+++ b/opensoundscape/datasets.py
@@ -60,7 +60,6 @@ def annotations_with_overlaps_with_clip(df, begin, end):
     ]
 
 
-
 # TODO:
 # - Should be able to process WAV or MP3 files?
 # - Should use the opensoundscape.audio.Audio object, need to input and forward audio configuration
@@ -83,6 +82,7 @@ class Splitter(torch.utils.data.Dataset):
                 time (seconds), segment end time (seconds), segment audio, and present
                 classes separated by '|' if annotations were requested
     """
+
     def __init__(
         self,
         wavs,
@@ -108,6 +108,7 @@ class Splitter(torch.utils.data.Dataset):
 
     def __getitem__(self, item_idx):
         wav = self.wavs[item_idx]
+        suffix = wav.suffix
         annotation_prefix = self.wavs[item_idx].stem.split(".")[0]
 
         if self.annotations:
@@ -130,9 +131,9 @@ class Splitter(torch.utils.data.Dataset):
         if self.labels:
             annotation_df["class"] = annotation_df["class"].fillna("unknown")
             annotation_df["class"] = annotation_df["class"].apply(
-                lambda cls: self.labels_df[self.labels_df["raw"] == cls]["corrected"].values[
-                    0
-                ]
+                lambda cls: self.labels_df[self.labels_df["raw"] == cls][
+                    "corrected"
+                ].values[0]
             )
 
         num_segments = ceil(
@@ -161,12 +162,14 @@ class Splitter(torch.utils.data.Dataset):
                     segment_samples, segment_sample_begin, segment_sample_end = get_segment(
                         begin, end, wav_samples, wav_sample_rate
                     )
-                    write_wav(f"{destination}.WAV", segment_samples, wav_sample_rate)
+                    write_wav(
+                        f"{destination}.{suffix}", segment_samples, wav_sample_rate
+                    )
 
                     if idx == num_segments - 1:
-                        to_append = f"{wav},{annotation_file},{wav_times[segment_sample_begin]},{wav_times[-1]},{destination}.WAV"
+                        to_append = f"{wav},{annotation_file},{wav_times[segment_sample_begin]},{wav_times[-1]},{destination}.{suffix}"
                     else:
-                        to_append = f"{wav},{annotation_file},{wav_times[segment_sample_begin]},{wav_times[segment_sample_end]},{destination}.WAV"
+                        to_append = f"{wav},{annotation_file},{wav_times[segment_sample_begin]},{wav_times[segment_sample_end]},{destination}.{suffix}"
                     to_append += f",{'|'.join(overlaps['class'].unique())}"
 
                     outputs.append(to_append)
@@ -174,12 +177,12 @@ class Splitter(torch.utils.data.Dataset):
                 segment_samples, segment_sample_begin, segment_sample_end = get_segment(
                     begin, end, wav_samples, wav_sample_rate
                 )
-                write_wav(f"{destination}.WAV", segment_samples, wav_sample_rate)
+                write_wav(f"{destination}.{suffix}", segment_samples, wav_sample_rate)
 
                 if idx == num_segments - 1:
-                    to_append = f"{wav},{wav_times[segment_sample_begin]},{wav_times[-1]},{destination}.WAV"
+                    to_append = f"{wav},{wav_times[segment_sample_begin]},{wav_times[-1]},{destination}.{suffix}"
                 else:
-                    to_append = f"{wav},{wav_times[segment_sample_begin]},{wav_times[segment_sample_end]},{destination}.WAV"
+                    to_append = f"{wav},{wav_times[segment_sample_begin]},{wav_times[segment_sample_end]},{destination}.{suffix}"
 
                 outputs.append(to_append)
 


### PR DESCRIPTION
Currently works with WAV files (case insensitive). The `Splitter` `Dataset` object is available in `opensoundscape/datasets.py`. Console access to `Splitter` is available via the `split_audio` command in `opensoundscape`.