### PR TITLE
Modify default splitting behavior

### DIFF
--- a/opensoundscape/datasets.py
+++ b/opensoundscape/datasets.py
@@ -46,12 +46,13 @@ class Splitter(torch.utils.data.Dataset):
     """ A PyTorch Dataset for splitting a WAV files
 
     Inputs:
-        wavs:               A list of WAV files to split
-        annotations:        Should we search for corresponding annotations files? (default: False)
-        label_corrections:  Specify a correction labels CSV file w/ column headers "raw" and "corrected" (default: None)
-        overlap:            How much overlap should there be between samples (units: seconds, default: 1)
-        duration:           How long should each segment be? (units: seconds, default: 5)
-        output_directory    Where should segments be written? (default: segments/)
+        wavs:                   A list of WAV files to split
+        annotations:            Should we search for corresponding annotations files? (default: False)
+        label_corrections:      Specify a correction labels CSV file w/ column headers "raw" and "corrected" (default: None)
+        overlap:                How much overlap should there be between samples (units: seconds, default: 1)
+        duration:               How long should each segment be? (units: seconds, default: 5)
+        output_directory        Where should segments be written? (default: segments/)
+        include_last_segment:   Do you want to include the last segment? (default: False)
 
     Effects:
         - Segments will be written to the output_directory
@@ -70,6 +71,7 @@ class Splitter(torch.utils.data.Dataset):
         overlap=1,
         duration=5,
         output_directory="segments",
+        include_last_segment=False,
     ):
         self.wavs = list(wavs)
 
@@ -81,6 +83,7 @@ class Splitter(torch.utils.data.Dataset):
         self.overlap = overlap
         self.duration = duration
         self.output_directory = output_directory
+        self.include_last_segment = include_last_segment
 
     def __len__(self):
         return len(self.wavs)
@@ -122,8 +125,11 @@ class Splitter(torch.utils.data.Dataset):
         outputs = []
         for idx in range(num_segments):
             if idx == num_segments - 1:
-                end = wav_duration
-                begin = end - self.duration
+                if self.include_last_segment:
+                    end = wav_duration
+                    begin = end - self.duration
+                else:
+                    continue
             else:
                 begin = self.duration * idx - self.overlap * idx
                 end = begin + self.duration

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -54,6 +54,11 @@ def one_min_audio_list():
     return [Path("tests/1min.wav")]
 
 
+@pytest.fixture()
+def binary_from_audio_df():
+    return pd.read_csv("tests/input.csv")
+
+
 def test_basic_splitting_operation_default(
     temporary_split_storage, splitter_results_default, one_min_audio_list
 ):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -23,7 +23,20 @@ def temporary_split_storage(request):
 
 
 @pytest.fixture()
-def splitter_results(request):
+def splitter_results_default(request):
+    split0 = Path(f"{tmp_path}/5c5f4b5484945db37725533cd6a530f7.wav")
+    split1 = Path(f"{tmp_path}/d174a640f6b3ed0cb42ca686576f663b.wav")
+
+    def fin():
+        split0.unlink()
+        split1.unlink()
+
+    request.addfinalizer(fin)
+    return split0, split1
+
+
+@pytest.fixture()
+def splitter_results_last(request):
     split0 = Path(f"{tmp_path}/27f99f7d921cc464de465411f075e933.wav")
     split1 = Path(f"{tmp_path}/4202e0f72c56cb0763db165ffbbc8bc6.wav")
 
@@ -40,12 +53,12 @@ def one_min_audio_list():
     return [Path("tests/1min.wav")]
 
 
-def test_basic_splitting_operation(
-    temporary_split_storage, splitter_results, one_min_audio_list
+def test_basic_splitting_operation_default(
+    temporary_split_storage, splitter_results_default, one_min_audio_list
 ):
     dataset = Splitter(
         one_min_audio_list,
-        duration=30,
+        duration=25,
         overlap=0,
         output_directory=temporary_split_storage,
     )
@@ -64,6 +77,36 @@ def test_basic_splitting_operation(
             results.append(output)
     assert len(results) == 2
 
-    split0, split1 = splitter_results
+    split0, split1 = splitter_results_default
+    assert split0.exists()
+    assert split1.exists()
+
+
+def test_basic_splitting_operation_with_include_last_segment(
+    temporary_split_storage, splitter_results_last, one_min_audio_list
+):
+    dataset = Splitter(
+        one_min_audio_list,
+        duration=30,
+        overlap=0,
+        output_directory=temporary_split_storage,
+        include_last_segment=True,
+    )
+
+    dataloader = DataLoader(
+        dataset,
+        batch_size=1,
+        shuffle=False,
+        num_workers=1,
+        collate_fn=Splitter.collate_fn,
+    )
+
+    results = []
+    for data in dataloader:
+        for output in data:
+            results.append(output)
+    assert len(results) == 2
+
+    split0, split1 = splitter_results_last
     assert split0.exists()
     assert split1.exists()


### PR DESCRIPTION
The default splitting behavior should drop the last segment (may have a larger overlap). Added keyword arg `include_last_segment` to `Splitter` dataset. Additionally, add a test for default and non-default behavior (latter already exists).