### PR TITLE
Class balanced upsampling for DataFrames

### DIFF
--- a/opensoundscape/data_selection.py
+++ b/opensoundscape/data_selection.py
@@ -2,6 +2,7 @@
 import pandas as pd
 from sklearn.model_selection import train_test_split
 from copy import copy
+from itertools import repeat
 
 
 def expand_multi_labeled(input_df):
@@ -60,3 +61,40 @@ def binary_train_valid_split(input_df, label, train_size=0.8, random_state=101):
         valid_dfs[idx] = valid
 
     return pd.concat(train_dfs), pd.concat(valid_dfs)
+
+
+def upsample(input_df, label_column="Labels", random_state=None):
+    """ Given a input DataFrame upsample to maximum value
+
+    Upsampling removes the class imbalance in your dataset. Rows for each label
+    are repeated up to `max_count // rows`. Then, we randomly sample the rows
+    to fill up to `max_count`.
+
+    Input:
+        input_df:       A DataFrame to upsample
+        label_column:   The column to draw unique labels from
+        random_state:   Set the random_state during sampling
+
+    Output:
+        df:             An upsampled DataFrame
+    """
+
+    unique_labels = input_df[label_column].unique()
+    label_counts = input_df.groupby(by=label_column)[label_column].count()
+    max_count = label_counts.max()
+
+    dfs = [None] * unique_labels.shape[0]
+    for idx, unique_label in enumerate(unique_labels):
+        sub_df = input_df[input_df[label_column] == unique_label]
+        num_replicates, remainder = divmod(max_count, sub_df.shape[0])
+
+        if random_state:
+            random_df = sub_df.sample(n=remainder, random_state=random_state)
+        else:
+            random_df = sub_df.sample(n=remainder)
+
+        repeat_df = pd.concat(repeat(sub_df, num_replicates))
+
+        dfs[idx] = pd.concat([repeat_df, random_df])
+
+    return pd.concat(dfs)

--- a/tests/test_data_selection.py
+++ b/tests/test_data_selection.py
@@ -4,6 +4,11 @@ import opensoundscape.data_selection as selection
 import pandas as pd
 
 
+@pytest.fixture
+def upsample_df():
+    return pd.read_csv("tests/to_upsample.csv")
+
+
 def test_expand_multi_labeled_dataframe():
     input_df = pd.DataFrame({"Labels": ["hello|world"]})
     output_df = pd.DataFrame({"Labels": ["hello", "world"]})
@@ -35,3 +40,9 @@ def test_train_valid_binary_split():
     assert valid_df[valid_df["Labels"] == "hello"]["Labels"].count() == 1
     assert train_df[train_df["Labels"] == "world"]["Labels"].count() == 4
     assert valid_df[valid_df["Labels"] == "world"]["Labels"].count() == 1
+
+
+def test_upsample_basic(upsample_df):
+    for _ in range(100):
+        upsampled_df = selection.upsample(upsample_df)
+        assert upsampled_df.shape[0] == 20

--- a/tests/to_upsample.csv
+++ b/tests/to_upsample.csv
@@ -1,0 +1,14 @@
+Number,Labels
+1,hello
+2,hello
+3,hello
+4,hello
+5,hello
+6,hello
+7,hello
+8,hello
+9,hello
+10,hello
+11,world
+12,world
+13,world


### PR DESCRIPTION
Implement class balanced upsampling for DataFrames. For each class:
- Repeat rows up to `max_count // num_rows`
- Randomly sample rows up to `max_count % num_rows`
- Concatenate repeated rows and sampled rows