### PR TITLE
Fix scaling issue with BinaryFromAudio

### DIFF
--- a/opensoundscape/datasets.py
+++ b/opensoundscape/datasets.py
@@ -248,7 +248,7 @@ class BinaryFromAudio(torch.utils.data.Dataset):
         audio_p = Path(row[self.audio_column])
         audio = Audio.from_file(audio_p)
         spectrogram = Spectrogram.from_audio(audio)
-        spectrogram = spectrogram.min_max_scale(feature_range=(0, 255))
+        spectrogram = spectrogram.linear_scale(feature_range=(0, 255))
 
         image = Image.fromarray(spectrogram.spectrogram)
         image = image.convert("RGB")

--- a/opensoundscape/datasets.py
+++ b/opensoundscape/datasets.py
@@ -248,6 +248,7 @@ class BinaryFromAudio(torch.utils.data.Dataset):
         audio_p = Path(row[self.audio_column])
         audio = Audio.from_file(audio_p)
         spectrogram = Spectrogram.from_audio(audio)
+        spectrogram = spectrogram.min_max_scale(feature_range=(0, 255))
 
         image = Image.fromarray(spectrogram.spectrogram)
         image = image.convert("RGB")

--- a/opensoundscape/helpers.py
+++ b/opensoundscape/helpers.py
@@ -75,6 +75,20 @@ def min_max_scale(array, feature_range=(0, 1)):
     return scale_factor * (array - array_min) + bottom
 
 
+def linear_scale(array, in_range=(0, 1), out_range=(0, 255)):
+    """ Translate from range in_range to out_range
+
+    Inputs:
+        in_range: The starting range [default: (0, 1)]
+        out_range: The output range [default: (0, 255)]
+
+    Outputs:
+        new_array: A translated array
+    """
+    scale_factor = (out_range[1] - out_range[0]) / (in_range[1] - in_range[0])
+    return scale_factor * (array - in_range[0]) + out_range[0]
+
+
 def jitter(x, width, distribution="gaussian"):
     """
     Jitter (add random noise to) each value of x

--- a/opensoundscape/spectrogram.py
+++ b/opensoundscape/spectrogram.py
@@ -5,7 +5,7 @@
 from scipy import signal
 import numpy as np
 from opensoundscape.audio import Audio
-from opensoundscape.helpers import min_max_scale
+from opensoundscape.helpers import min_max_scale, linear_scale
 import warnings
 import pickle
 
@@ -14,11 +14,7 @@ class Spectrogram:
     """ Immutable spectrogram container
     """
 
-    __slots__ = (
-        "frequencies",
-        "times",
-        "spectrogram",
-    )  # , "overlap", "segment_length")
+    __slots__ = ("frequencies", "times", "spectrogram", "decibel_limits")
 
     def __init__(self, spectrogram, frequencies, times):
         if not isinstance(spectrogram, np.ndarray):
@@ -55,6 +51,7 @@ class Spectrogram:
         super(Spectrogram, self).__setattr__("frequencies", frequencies)
         super(Spectrogram, self).__setattr__("times", times)
         super(Spectrogram, self).__setattr__("spectrogram", spectrogram)
+        super(Spectrogram, self).__setattr__("decibel_limits", (-100, -20))
 
     @classmethod
     def from_audio(
@@ -101,7 +98,9 @@ class Spectrogram:
         spectrogram[spectrogram > max_db] = max_db
         spectrogram[spectrogram < min_db] = min_db
 
-        return cls(spectrogram, frequencies, times)
+        new_obj = cls(spectrogram, frequencies, times)
+        super(Spectrogram, new_obj).__setattr__("decibel_limits", decibel_limits)
+        return new_obj
 
     def __setattr__(self, name, value):
         raise AttributeError("Spectrogram's cannot be modified")
@@ -110,10 +109,14 @@ class Spectrogram:
         return f"<Spectrogram(spectrogram={self.spectrogram.shape}, frequencies={self.frequencies.shape}, times={self.times.shape})>"
 
     def min_max_scale(self, feature_range=(0, 1)):
-        """ Linearly rescale spectrogram values to a range of values
+        """
+
+        Linearly rescale spectrogram values to a range of values using
+        in_range as minimum and maximum
         
         Args:
             feature_range: tuple of (low,high) values for output
+
         Returns:
             Spectrogram object with values rescaled to feature_range
         """
@@ -127,6 +130,34 @@ class Spectrogram:
 
         return Spectrogram(
             min_max_scale(self.spectrogram, feature_range=feature_range),
+            self.frequencies,
+            self.times,
+        )
+
+    def linear_scale(self, feature_range=(0, 1)):
+        """
+
+        Linearly rescale spectrogram values to a range of values
+        using in_range as decibel_limits
+        
+        Args:
+            feature_range: tuple of (low,high) values for output
+
+        Returns:
+            Spectrogram object with values rescaled to feature_range
+        """
+
+        if len(feature_range) != 2:
+            raise AttributeError(
+                "Error: `feature_range` doesn't look like a 2-element tuple?"
+            )
+        if feature_range[1] < feature_range[0]:
+            raise AttributeError("Error: `feature_range` isn't increasing?")
+
+        return Spectrogram(
+            linear_scale(
+                self.spectrogram, in_range=self.decibel_limits, out_range=feature_range
+            ),
             self.frequencies,
             self.times,
         )

--- a/opensoundscape/spectrogram.py
+++ b/opensoundscape/spectrogram.py
@@ -5,6 +5,7 @@
 from scipy import signal
 import numpy as np
 from opensoundscape.audio import Audio
+from opensoundscape.helpers import min_max_scale
 import warnings
 import pickle
 
@@ -71,7 +72,6 @@ class Spectrogram:
             window_type="hann": see scipy.signal.spectrogram docs for description of window parameter
             window_samples=512: number of audio samples per spectrogram window (pixel)
             overlap_samples=256: number of samples shared by consecutive windows
-            decibels=True: convert the spectrogram values to decibelss (dB)
             decibel_limits = (-100,-20) : limit the dB values to (min,max) (lower values set to min, higher values set to max)
             
         Returns:
@@ -125,11 +125,8 @@ class Spectrogram:
         if feature_range[1] < feature_range[0]:
             raise AttributeError("Error: `feature_range` isn't increasing?")
 
-        spect_min = self.spectrogram.min()
-        spect_max = self.spectrogram.min()
-        scale_factor = (feature_range[1] - feature_range[0]) / (spect_max - spect_min)
         return Spectrogram(
-            scale_factor * (self.spectrogram - spect_min) + feature_range[0],
+            min_max_scale(self.spectrogram, feature_range=feature_range),
             self.frequencies,
             self.times,
         )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -6,6 +6,8 @@ from shutil import rmtree
 from opensoundscape.datasets import Splitter, BinaryFromAudio
 from torch.utils.data import DataLoader
 import pandas as pd
+import numpy as np
+from PIL import Image
 
 
 tmp_path = "tests/_tmp_split"
@@ -136,3 +138,13 @@ def test_binary_from_audio_spec_augment(binary_from_audio_df):
     )
     assert dataset[0]["X"].shape == (1, 225, 226)
     assert dataset[0]["y"].shape == (1,)
+
+
+def test_binary_from_audio_to_image(binary_from_audio_df):
+    dataset = BinaryFromAudio(binary_from_audio_df)
+
+    pixels = dataset[0]["X"].numpy()
+
+    assert (pixels >= 0).all()
+    assert (pixels <= 1).all()
+    assert pixels.max() > 0.9


### PR DESCRIPTION
`BinaryFromAudio` during the `Spectrogram` phase was being converted to decibels. When subsequently converting to an image everything was being set to 0. Additionally, add a test that ensures `BinaryFromAudio` doesn't create an array of zeros.