### PR TITLE
#146 audio intialization should fail in certain cases

### DIFF
--- a/opensoundscape/audio.py
+++ b/opensoundscape/audio.py
@@ -25,14 +25,31 @@ class OpsoLoadAudioInputTooLong(Exception):
 
 
 class Audio:
-    """ Immutable container for audio samples
+    """ Container for audio samples
     """
 
     __slots__ = ("samples", "sample_rate")
 
     def __init__(self, samples, sample_rate):
+        samples_error = None
+        if not isinstance(samples, np.ndarray):
+            samples_error = (
+                "Initializing an Audio object requires samples to be a numpy array"
+            )
         self.samples = samples
-        self.sample_rate = sample_rate
+
+        try:
+            self.sample_rate = int(sample_rate)
+        except ValueError:
+            sample_rate_error = f"Initializing an Audio object requires an integer sample_rate, got `{sample_rate}`"
+            if samples_error:
+                raise ValueError(
+                    f"Audio initialization failed with:\n{samples_error}\n{sample_rate_error}"
+                )
+            raise ValueError(f"Audio initialization failed with:\n{sample_rate_error}")
+
+        if samples_error:
+            raise ValueError(f"Audio initialization failed with:\n{samples_error}")
 
     @classmethod
     def from_file(

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -163,3 +163,13 @@ def test_save(silence_10s_mp3_str, saved_wav):
 def test_save_extension_error(silence_10s_mp3_str, saved_mp3):
     with pytest.raises(TypeError):
         Audio.from_file(silence_10s_mp3_str).save(saved_mp3)
+
+
+def test_audio_constructor_should_fail_on_file(veryshort_wav_str):
+    with pytest.raises(ValueError):
+        Audio(veryshort_wav_str, 22050)
+
+
+def test_audio_constructor_should_fail_on_non_integer_sample_rate():
+    with pytest.raises(ValueError):
+        Audio(np.zeros(10), "fail...")


### PR DESCRIPTION
Fixes #146 

- If `samples` is not a numpy array fail to initialize
- If `samples_rate` is not an integer fail to initialize
- If the user tried `Audio(not_a_numpy_array, not_an_integer)` they should see both errors