### PR TITLE
Fix CUDA semantics for torch.train and torch.predict

### DIFF
--- a/opensoundscape/torch/predict.py
+++ b/opensoundscape/torch/predict.py
@@ -37,7 +37,7 @@ def predict(
     """
 
     if torch.cuda.is_available():
-        device = torch.device("cuda:0")
+        device = torch.device("cuda")
     else:
         device = torch.device("cpu")
     model.eval()
@@ -53,13 +53,13 @@ def predict(
     # run prediction
     all_predictions = []
     for i, inputs in enumerate(dataloader):
-        predictions = model(inputs["X"])
+        predictions = model(inputs["X"].to(device))
         if apply_softmax:
             softmax_val = softmax(predictions, 1).detach().cpu().numpy()
             for x in softmax_val:
                 all_predictions.append(x)
         else:
-            for x in predictions.detach().numpy():
+            for x in predictions.detach().cpu().numpy():
                 all_predictions.append(list(x))  # .astype('float64')
 
     img_paths = prediction_dataset.df[prediction_dataset.filename_column].values

--- a/opensoundscape/torch/train.py
+++ b/opensoundscape/torch/train.py
@@ -79,7 +79,7 @@ def train(
             f.writelines(yaml.dump(metadata))
 
     if torch.cuda.is_available():
-        device = torch.device("cuda:0")
+        device = torch.device("cuda")
     else:
         device = torch.device("cpu")
 
@@ -105,8 +105,8 @@ def train(
         model.train()
         for t in train_loader:
             X, y = t["X"], t["y"]
-            X.to(device)
-            y.to(device)
+            X = X.to(device)
+            y = y.to(device)
             targets = y.squeeze(1)
 
             if tensor_augment:
@@ -128,7 +128,7 @@ def train(
 
             train_metrics.update_loss(loss.clone().detach().item())
             predictions = outputs.clone().detach().argmax(dim=1)
-            train_metrics.update_metrics(targets, predictions)
+            train_metrics.update_metrics(targets.cpu(), predictions.cpu())
 
         if print_logging:
             print("  Validating.")
@@ -137,13 +137,13 @@ def train(
         with torch.no_grad():
             for t in valid_loader:
                 X, y = t["X"], t["y"]
-                X.to(device)
-                y.to(device)
+                X = X.to(device)
+                y = y.to(device)
                 targets = y.squeeze(1)
 
                 outputs = model(X)
                 predictions = outputs.clone().detach().argmax(dim=1)
-                valid_metrics.update_metrics(targets, predictions)
+                valid_metrics.update_metrics(targets.cpu(), predictions.cpu())
 
         # Save weights at every logging interval and at the last epoch
         if (epoch % log_every == 0) or (epoch == epochs - 1):


### PR DESCRIPTION
Fix the CUDA semantics for `torch.train.train` and `torch.predict.predict`. `Tensor.cuda()` returns a copy of the tensor on the device, therefore `X.cuda()` needs to be `X = X.cuda()`. It appears this is unnecessary for models.