### PR TITLE
Fix normalization bug & add validation saving

### DIFF
--- a/opensoundscape/datasets.py
+++ b/opensoundscape/datasets.py
@@ -249,7 +249,7 @@ class SingleTargetAudioDataset(torch.utils.data.Dataset):
         overlay_weight="random",
         audio_sample_rate=22050,
         debug=None,
-#        white_black_pct=(50, 0),
+        #        white_black_pct=(50, 0),
     ):
         self.df = df
         self.filename_column = filename_column
@@ -267,12 +267,12 @@ class SingleTargetAudioDataset(torch.utils.data.Dataset):
                 f"overlay_weight not in 0<overlay_weight<1 (given overlay_weight: {overlay_weight})"
             )
         self.overlay_weight = overlay_weight
-#        self.white_black_pct = white_black_pct
-        
-        self.mean = torch.tensor([.5 for _ in range(3)]) #[0.8013 for _ in range(3)]) 
-        self.std_dev = ([.5 for _ in range(3)]) #0.1576 for _ in range(3)])
+        #        self.white_black_pct = white_black_pct
+
+        self.mean = torch.tensor([0.5 for _ in range(3)])  # [0.8013 for _ in range(3)])
+        self.std_dev = [0.5 for _ in range(3)]  # 0.1576 for _ in range(3)])
         self.transform = self.set_transform(add_noise=add_noise)
-        
+
         self.label_dict = label_dict
         self.audio_sample_rate = audio_sample_rate
         self.debug = debug
@@ -364,36 +364,35 @@ class SingleTargetAudioDataset(torch.utils.data.Dataset):
     def upsample(self):
         raise NotImplementedError("Upsampling is not implemented yet")
 
-#     def increase_contrast(self, rgb_tensor, white_pct, black_pct):
-#         """makes quietest white_pct white and loudest black_pct pixels black   
-#
-#         takes rgb_tensor size (3, width, height) 
-# 
-#         for instance, if white_pct = 40 and black_pct = 1
-#         the quietest 50% of pixels become 1 (white)
-#         the loudest 1% of pixels become black (0)
-#         intermediate values are scaled linearly from 0 to 1
-#        
-#         returns rgb tensor with rescaled values
-#        
-#         """
-#         from opensoundscape.helpers import linear_scale
-#        
-#         #convert torch tensor to numpy array of shape (3,width,height)
-#         rgb_array = rgb_tensor.numpy()
-#        
-#         #find values of pixels: the quietest to become black (0) and the loudest to become white (1)
-#         max_value_to_0black = np.percentile(rgb_array,black_pct)
-#         min_value_to_1white = np.percentile(rgb_array,100-white_pct)
-#
-#         # linearly re-scale pixel values such that the desired black percentiles are <=0 and desired white percentiles are >=1
-#         rgb_array = linear_scale(rgb_array,(max_value_to_0black,min_value_to_1white),(0,1))
-#        
-#         # limit values to the range [0,1]
-#         rgb_array = np.clip(rgb_array,0,1) 
-#        
-#         return torch.from_numpy(rgb_array)
-
+    #     def increase_contrast(self, rgb_tensor, white_pct, black_pct):
+    #         """makes quietest white_pct white and loudest black_pct pixels black
+    #
+    #         takes rgb_tensor size (3, width, height)
+    #
+    #         for instance, if white_pct = 40 and black_pct = 1
+    #         the quietest 50% of pixels become 1 (white)
+    #         the loudest 1% of pixels become black (0)
+    #         intermediate values are scaled linearly from 0 to 1
+    #
+    #         returns rgb tensor with rescaled values
+    #
+    #         """
+    #         from opensoundscape.helpers import linear_scale
+    #
+    #         #convert torch tensor to numpy array of shape (3,width,height)
+    #         rgb_array = rgb_tensor.numpy()
+    #
+    #         #find values of pixels: the quietest to become black (0) and the loudest to become white (1)
+    #         max_value_to_0black = np.percentile(rgb_array,black_pct)
+    #         min_value_to_1white = np.percentile(rgb_array,100-white_pct)
+    #
+    #         # linearly re-scale pixel values such that the desired black percentiles are <=0 and desired white percentiles are >=1
+    #         rgb_array = linear_scale(rgb_array,(max_value_to_0black,min_value_to_1white),(0,1))
+    #
+    #         # limit values to the range [0,1]
+    #         rgb_array = np.clip(rgb_array,0,1)
+    #
+    #         return torch.from_numpy(rgb_array)
 
     def __len__(self):
         return self.df.shape[0]
@@ -430,10 +429,10 @@ class SingleTargetAudioDataset(torch.utils.data.Dataset):
         # apply desired random transformations to image and convert to tensor
         image = image.convert("RGB")
         X = self.transform(image)
-        
-#        #re-scale pixel values to use entire range, increasing image contrast
-#        if self.white_black_pct is not None:
-#             X = self.increase_contrast(X, self.white_black_pct[0], self.white_black_pct[1])
+
+        #        #re-scale pixel values to use entire range, increasing image contrast
+        #        if self.white_black_pct is not None:
+        #             X = self.increase_contrast(X, self.white_black_pct[0], self.white_black_pct[1])
 
         if self.debug:
             from torchvision.utils import save_image

--- a/opensoundscape/datasets.py
+++ b/opensoundscape/datasets.py
@@ -249,7 +249,6 @@ class SingleTargetAudioDataset(torch.utils.data.Dataset):
         overlay_weight="random",
         audio_sample_rate=22050,
         debug=None,
-        #        white_black_pct=(50, 0),
     ):
         self.df = df
         self.filename_column = filename_column
@@ -267,7 +266,6 @@ class SingleTargetAudioDataset(torch.utils.data.Dataset):
                 f"overlay_weight not in 0<overlay_weight<1 (given overlay_weight: {overlay_weight})"
             )
         self.overlay_weight = overlay_weight
-        #        self.white_black_pct = white_black_pct
 
         self.mean = torch.tensor([0.5 for _ in range(3)])  # [0.8013 for _ in range(3)])
         self.std_dev = [0.5 for _ in range(3)]  # 0.1576 for _ in range(3)])
@@ -364,36 +362,6 @@ class SingleTargetAudioDataset(torch.utils.data.Dataset):
     def upsample(self):
         raise NotImplementedError("Upsampling is not implemented yet")
 
-    #     def increase_contrast(self, rgb_tensor, white_pct, black_pct):
-    #         """makes quietest white_pct white and loudest black_pct pixels black
-    #
-    #         takes rgb_tensor size (3, width, height)
-    #
-    #         for instance, if white_pct = 40 and black_pct = 1
-    #         the quietest 50% of pixels become 1 (white)
-    #         the loudest 1% of pixels become black (0)
-    #         intermediate values are scaled linearly from 0 to 1
-    #
-    #         returns rgb tensor with rescaled values
-    #
-    #         """
-    #         from opensoundscape.helpers import linear_scale
-    #
-    #         #convert torch tensor to numpy array of shape (3,width,height)
-    #         rgb_array = rgb_tensor.numpy()
-    #
-    #         #find values of pixels: the quietest to become black (0) and the loudest to become white (1)
-    #         max_value_to_0black = np.percentile(rgb_array,black_pct)
-    #         min_value_to_1white = np.percentile(rgb_array,100-white_pct)
-    #
-    #         # linearly re-scale pixel values such that the desired black percentiles are <=0 and desired white percentiles are >=1
-    #         rgb_array = linear_scale(rgb_array,(max_value_to_0black,min_value_to_1white),(0,1))
-    #
-    #         # limit values to the range [0,1]
-    #         rgb_array = np.clip(rgb_array,0,1)
-    #
-    #         return torch.from_numpy(rgb_array)
-
     def __len__(self):
         return self.df.shape[0]
 
@@ -429,10 +397,6 @@ class SingleTargetAudioDataset(torch.utils.data.Dataset):
         # apply desired random transformations to image and convert to tensor
         image = image.convert("RGB")
         X = self.transform(image)
-
-        #        #re-scale pixel values to use entire range, increasing image contrast
-        #        if self.white_black_pct is not None:
-        #             X = self.increase_contrast(X, self.white_black_pct[0], self.white_black_pct[1])
 
         if self.debug:
             from torchvision.utils import save_image

--- a/opensoundscape/datasets.py
+++ b/opensoundscape/datasets.py
@@ -221,10 +221,6 @@ class SingleTargetAudioDataset(torch.utils.data.Dataset):
             When not 'random', should be a float between 0 and 1 [default: 'random']
         audio_sample_rate: resample audio to this sample rate; specify None to use original audio sample rate
             default: 22050
-        white_black_pct: tuple (white_pct,black_pct) increase contrast to make this percentage of pixels of spectrogram black/white
-            result: whitest (quietest) white_percentile pixels become white, blackest (loudest) black_pct pixels become black; linear scale for intermediate values
-            default: (50,0)
-            pass `None` to skip this transformation
         debug: path to save img files, images are created from the tensor immediately before it is returned
             default: None (do not save)
 
@@ -252,7 +248,6 @@ class SingleTargetAudioDataset(torch.utils.data.Dataset):
         overlay_prob=0.2,
         overlay_weight="random",
         audio_sample_rate=22050,
-        white_black_pct=(50,0),
         debug=None,
     ):
         self.df = df
@@ -271,10 +266,13 @@ class SingleTargetAudioDataset(torch.utils.data.Dataset):
                 f"overlay_weight not in 0<overlay_weight<1 (given overlay_weight: {overlay_weight})"
             )
         self.overlay_weight = overlay_weight
+
+        self.mean = torch.tensor([.5 for _ in range(3)]) #[0.8013 for _ in range(3)]) 
+        self.std_dev = ([.5 for _ in range(3)]) #0.1576 for _ in range(3)])
         self.transform = self.set_transform(add_noise=add_noise)
+        
         self.label_dict = label_dict
         self.audio_sample_rate = audio_sample_rate
-        self.white_black_pct = white_black_pct
         self.debug = debug
 
     def set_transform(self, add_noise):
@@ -293,6 +291,8 @@ class SingleTargetAudioDataset(torch.utils.data.Dataset):
             )
 
         transform_list.append(transforms.ToTensor())
+        transform_list.append(transforms.Normalize(self.mean, self.std_dev))
+
         return transforms.Compose(transform_list)
 
     def random_audio_trim(self, audio, audio_length, audio_path):
@@ -362,35 +362,35 @@ class SingleTargetAudioDataset(torch.utils.data.Dataset):
     def upsample(self):
         raise NotImplementedError("Upsampling is not implemented yet")
     
-    def increase_contrast(self, rgb_tensor, white_pct, black_pct):
-        """makes quietest white_pct white and loudest black_pct pixels black
+#     def increase_contrast(self, rgb_tensor, white_pct, black_pct):
+#         """makes quietest white_pct white and loudest black_pct pixels black
         
-        takes rgb_tensor size (3, width, height) 
+#         takes rgb_tensor size (3, width, height) 
         
-        for instance, if white_pct = 40 and black_pct = 1
-        the quietest 50% of pixels become 1 (white)
-        the loudest 1% of pixels become black (0)
-        intermediate values are scaled linearly from 0 to 1
+#         for instance, if white_pct = 40 and black_pct = 1
+#         the quietest 50% of pixels become 1 (white)
+#         the loudest 1% of pixels become black (0)
+#         intermediate values are scaled linearly from 0 to 1
         
-        returns rgb tensor with rescaled values
+#         returns rgb tensor with rescaled values
         
-        """
-        from opensoundscape.helpers import linear_scale
+#         """
+#         from opensoundscape.helpers import linear_scale
         
-        #convert torch tensor to numpy array of shape (3,width,height)
-        rgb_array = rgb_tensor.numpy()
+#         #convert torch tensor to numpy array of shape (3,width,height)
+#         rgb_array = rgb_tensor.numpy()
         
-        #find values of pixels: the quietest to become black (0) and the loudest to become white (1)
-        max_value_to_0black = np.percentile(rgb_array,black_pct)
-        min_value_to_1white = np.percentile(rgb_array,100-white_pct)
+#         #find values of pixels: the quietest to become black (0) and the loudest to become white (1)
+#         max_value_to_0black = np.percentile(rgb_array,black_pct)
+#         min_value_to_1white = np.percentile(rgb_array,100-white_pct)
 
-        # linearly re-scale pixel values such that the desired black percentiles are <=0 and desired white percentiles are >=1
-        rgb_array = linear_scale(rgb_array,(max_value_to_0black,min_value_to_1white),(0,1))
+#         # linearly re-scale pixel values such that the desired black percentiles are <=0 and desired white percentiles are >=1
+#         rgb_array = linear_scale(rgb_array,(max_value_to_0black,min_value_to_1white),(0,1))
         
-        # limit values to the range [0,1]
-        rgb_array = np.clip(rgb_array,0,1) 
+#         # limit values to the range [0,1]
+#         rgb_array = np.clip(rgb_array,0,1) 
         
-        return torch.from_numpy(rgb_array)
+#         return torch.from_numpy(rgb_array)
 
     def __len__(self):
         return self.df.shape[0]
@@ -429,8 +429,8 @@ class SingleTargetAudioDataset(torch.utils.data.Dataset):
         X = self.transform(image)
         
         #re-scale pixel values to use entire range, increasing image contrast
-        if self.white_black_pct is not None:
-            X = self.increase_contrast(X, self.white_black_pct[0], self.white_black_pct[1])
+#         if self.white_black_pct is not None:
+#             X = self.increase_contrast(X, self.white_black_pct[0], self.white_black_pct[1])
         
         if self.debug:
             from torchvision.utils import save_image

--- a/opensoundscape/torch/train.py
+++ b/opensoundscape/torch/train.py
@@ -23,6 +23,7 @@ def train(
     tensor_augment=False,
     debug=False,
     print_logging=True,
+    save_scores=False,
 ):
     """ Train a model
 
@@ -41,6 +42,8 @@ def train(
         log_every:      Log statistics when epoch % log_every == 0 [default: 5]
         tensor_augment: Whether or not to use the tensor augment procedures [default: False]
         debug:          Whether or not to write intermediate images [default: False]
+        print_logging:  Whether to print training progress to stdout [default: True]
+        save_scores:    Whether to save the scores on the train/val set each epoch [default: False]
 
     Side Effects:
         Write a file `epoch-{epoch}.tar` containing (rate of `log_every`):
@@ -98,11 +101,16 @@ def train(
     # Model training
     stats = []
     for epoch in range(epochs):
+
+        # Train model
         if print_logging:
             print(f"Epoch {epoch}")
             print("  Training.")
         train_metrics = Metrics(model.fc.out_features)
         model.train()
+        
+        epoch_train_scores = []
+        epoch_train_targets = []
         for t in train_loader:
             X, y = t["X"], t["y"]
             X = X.to(device)
@@ -120,20 +128,34 @@ def train(
                 # Take from 1 dimension to 3 dimensions
                 X = torch.cat([X] * 3, dim=1)
 
+            # Run model
             outputs = model(X)
+            
+            # Learn from batch
             loss = loss_fn(outputs, targets)
             optimizer.zero_grad()
             loss.backward()
             optimizer.step()
 
+            # Update metrics with loss & class predictions for batch
             train_metrics.update_loss(loss.clone().detach().item())
-            predictions = outputs.clone().detach().argmax(dim=1)
-            train_metrics.update_metrics(targets.cpu(), predictions.cpu())
+            batch_scores = outputs.clone().detach()
+            batch_predictions = batch_scores.argmax(dim=1)
+            train_metrics.update_metrics(targets.cpu(), batch_predictions.cpu())
 
+            # Save copy of scores and true vals
+            if save_scores:
+                epoch_train_scores.extend([sample.numpy() for sample in batch_scores])
+                epoch_train_targets.extend(*y.clone().detach().reshape([1, len(y)]).numpy().tolist())
+            
+            
+        # Validate model
         if print_logging:
             print("  Validating.")
         valid_metrics = Metrics(model.fc.out_features)
         model.eval()
+        epoch_val_scores = []
+        epoch_val_targets = []
         with torch.no_grad():
             for t in valid_loader:
                 X, y = t["X"], t["y"]
@@ -141,10 +163,20 @@ def train(
                 y = y.to(device)
                 targets = y.squeeze(1)
 
+                # Run model
                 outputs = model(X)
-                predictions = outputs.clone().detach().argmax(dim=1)
-                valid_metrics.update_metrics(targets.cpu(), predictions.cpu())
-
+               
+                # Update metrics with class predictions for batch
+                batch_scores = outputs.clone().detach()
+                batch_predictions = batch_scores.argmax(dim=1) 
+                valid_metrics.update_metrics(targets.cpu(), batch_predictions.cpu())
+                
+                 
+                # Save copy of scores and true targets
+                if save_scores:
+                    epoch_val_scores.extend([sample.numpy() for sample in batch_scores])
+                    epoch_val_targets.extend(*y.clone().detach().reshape([1, len(y)]).numpy().tolist())
+        
         # Save weights at every logging interval and at the last epoch
         if (epoch % log_every == 0) or (epoch == epochs - 1):
             t_loss, t_acc, t_prec, t_rec, t_f1 = train_metrics.compute_metrics(
@@ -178,7 +210,17 @@ def train(
                     "labels_yaml": labels_yaml,
                 }
             )
-
+            
+            if save_scores:
+                epoch_results.update(
+                    {
+                        "train_scores": epoch_train_scores,
+                        "train_targets": epoch_train_targets,
+                        "valid_scores": epoch_val_scores,
+                        "valid_targets": epoch_val_targets,
+                    }
+                )
+            
             if save_dir is not None:
                 epoch_filename = f"{save_dir}/epoch-{epoch}.tar"
                 torch.save(epoch_results, epoch_filename)
@@ -187,3 +229,4 @@ def train(
 
     print("Training complete.")
     return
+

--- a/opensoundscape/torch/train.py
+++ b/opensoundscape/torch/train.py
@@ -108,7 +108,7 @@ def train(
             print("  Training.")
         train_metrics = Metrics(model.fc.out_features)
         model.train()
-        
+
         epoch_train_scores = []
         epoch_train_targets = []
         for t in train_loader:
@@ -130,7 +130,7 @@ def train(
 
             # Run model
             outputs = model(X)
-            
+
             # Learn from batch
             loss = loss_fn(outputs, targets)
             optimizer.zero_grad()
@@ -146,9 +146,10 @@ def train(
             # Save copy of scores and true vals
             if save_scores:
                 epoch_train_scores.extend([sample.numpy() for sample in batch_scores])
-                epoch_train_targets.extend(*y.clone().detach().reshape([1, len(y)]).numpy().tolist())
-            
-            
+                epoch_train_targets.extend(
+                    *y.clone().detach().reshape([1, len(y)]).numpy().tolist()
+                )
+
         # Validate model
         if print_logging:
             print("  Validating.")
@@ -165,18 +166,19 @@ def train(
 
                 # Run model
                 outputs = model(X)
-               
+
                 # Update metrics with class predictions for batch
                 batch_scores = outputs.clone().detach()
-                batch_predictions = batch_scores.argmax(dim=1) 
+                batch_predictions = batch_scores.argmax(dim=1)
                 valid_metrics.update_metrics(targets.cpu(), batch_predictions.cpu())
-                
-                 
+
                 # Save copy of scores and true targets
                 if save_scores:
                     epoch_val_scores.extend([sample.numpy() for sample in batch_scores])
-                    epoch_val_targets.extend(*y.clone().detach().reshape([1, len(y)]).numpy().tolist())
-        
+                    epoch_val_targets.extend(
+                        *y.clone().detach().reshape([1, len(y)]).numpy().tolist()
+                    )
+
         # Save weights at every logging interval and at the last epoch
         if (epoch % log_every == 0) or (epoch == epochs - 1):
             t_loss, t_acc, t_prec, t_rec, t_f1 = train_metrics.compute_metrics(
@@ -210,7 +212,7 @@ def train(
                     "labels_yaml": labels_yaml,
                 }
             )
-            
+
             if save_scores:
                 epoch_results.update(
                     {
@@ -220,7 +222,7 @@ def train(
                         "valid_targets": epoch_val_targets,
                     }
                 )
-            
+
             if save_dir is not None:
                 epoch_filename = f"{save_dir}/epoch-{epoch}.tar"
                 torch.save(epoch_results, epoch_filename)
@@ -229,4 +231,3 @@ def train(
 
     print("Training complete.")
     return
-

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -145,7 +145,10 @@ def test_single_target_audio_dataset_to_image(single_target_audio_dataset_df):
 
     pixels = dataset[0]["X"].numpy()
 
-    assert (pixels >= 0).all()
+    for pixel in pixels.flatten():
+        if pixel < 0:
+            print(pixel)
+    assert (pixels >= -1).all()
     assert (pixels <= 1).all()
     assert pixels.max() > 0.9
 


### PR DESCRIPTION
This pull request fixes the spectrogram normalization bug. 

It also adds a flag in `train()` for saving training and validation targets and model outputs in the model `tar` for easy histogram generation post-hoc.

After this PR is merged, we should make a minor/bugfix release of OpenSoundscape.