### PR TITLE
Allow overlay class choice in `SingleTargetAudioDataset`

### DIFF
--- a/opensoundscape/datasets.py
+++ b/opensoundscape/datasets.py
@@ -282,12 +282,11 @@ class SingleTargetAudioDataset(torch.utils.data.Dataset):
             raise ValueError(
                 "label_column must be specified to use max_overlay_num != 0"
             )
-        if (
-            self.overlay_class is not None
-            and self.overlay_class not in df[self.label_column]
+        if (self.overlay_class != "different") and (
+            self.overlay_class not in df[self.label_column]
         ):
             raise ValueError(
-                f"overlay_class must be a value in the label_column (got overlay_class {self.overlay_class} but labels {df[self.label_column].unique()})"
+                f"overlay_class must either be 'different' or a value in the label_column (got overlay_class {self.overlay_class} but labels {df[self.label_column].unique()})"
             )
 
         # Set up transform, including needed normalization variables
@@ -347,7 +346,7 @@ class SingleTargetAudioDataset(torch.utils.data.Dataset):
         with a weight
         """
         # Select a random file from a class of choice
-        if self.overlay_class:
+        if self.overlay_class == "different":
             choose_from = self.df[self.df[self.label_column] == self.overlay_class]
         # Select a random file from a different class
         else:

--- a/opensoundscape/datasets.py
+++ b/opensoundscape/datasets.py
@@ -282,8 +282,10 @@ class SingleTargetAudioDataset(torch.utils.data.Dataset):
             raise ValueError(
                 "label_column must be specified to use max_overlay_num != 0"
             )
-        if (self.overlay_class != "different") and (
-            self.overlay_class not in df[self.label_column]
+        if (
+            (self.max_overlay_num > 0)
+            and (self.overlay_class != "different")
+            and (self.overlay_class not in df[self.label_column])
         ):
             raise ValueError(
                 f"overlay_class must either be 'different' or a value in the label_column (got overlay_class {self.overlay_class} but labels {df[self.label_column].unique()})"

--- a/opensoundscape/datasets.py
+++ b/opensoundscape/datasets.py
@@ -345,12 +345,12 @@ class SingleTargetAudioDataset(torch.utils.data.Dataset):
         same length as the given image. Overlay the images on top of each other
         with a weight
         """
-        # Select a random file from a class of choice
-        if self.overlay_class == "different":
-            choose_from = self.df[self.df[self.label_column] == self.overlay_class]
         # Select a random file from a different class
-        else:
+        if self.overlay_class == "different":
             choose_from = self.df[self.df[self.label_column] != original_class]
+        # Select a random file from a class of choice
+        else:
+            choose_from = self.df[self.df[self.label_column] == self.overlay_class]
         overlay_path = np.random.choice(choose_from[self.filename_column].values)
         overlay_audio = Audio.from_file(
             overlay_path, sample_rate=self.audio_sample_rate

--- a/opensoundscape/datasets.py
+++ b/opensoundscape/datasets.py
@@ -202,31 +202,40 @@ class SingleTargetAudioDataset(torch.utils.data.Dataset):
         label_dict: a dictionary mapping numeric labels to class names,
             - for example: {0:'American Robin',1:'Northern Cardinal'}
             - pass `None` if you wish to retain numeric labels
-        filename_column: The column in the DataFrame which contains paths to data [default: Destination]
+        filename_column: The column in the DataFrame which contains paths to
+            data [default: Destination]
         from_audio: Whether the raw dataset is audio [default: True]
         label_column: The column with numeric labels if present [default: None]
         height: Height for resulting Tensor [default: 224]
         width: Width for resulting Tensor [default: 224]
         add_noise: Apply RandomAffine and ColorJitter filters [default: False]
         save_dir: Save images to a directory [default: None]
-        random_trim_length: Extract a clip of this many seconds of audio starting at a random time
-            If None, the original clip will be used [default: None]
-        extend_short_clips: If a file to be overlaid or trimmed from is too short,
-            extend it to the desired length by repeating it. [default: False]
-        max_overlay_num: The maximum number of additional images to overlay, each with probability overlay_prob [default: 0]
-        overlay_prob: Probability of an image from a different class being overlayed (combined as a weighted sum)
+        random_trim_length: Extract a clip of this many seconds of audio
+            starting at a random time. If None, the original clip will be used
+            [default: None]
+        extend_short_clips: If a file to be overlaid or trimmed from is too
+            short, extend it to the desired length by repeating it.
+            [default: False]
+        max_overlay_num: The maximum number of additional images to overlay,
+            each with probability overlay_prob [default: 0]
+        overlay_prob: Probability of an image from a different class being
+            overlayed (combined as a weighted sum)
             on the training image. typical values: 0, 0.66 [default: 0.2]
-        overlay_weight: The weight given to the overlaid image during augmentation.
-            When 'random', will randomly select a different weight between 0.2 and 0.5 for each overlay
-            When not 'random', should be a float between 0 and 1 [default: 'random']
+        overlay_weight: The weight given to the overlaid image during
+            augmentation. When 'random', will randomly select a different weight
+            between 0.2 and 0.5 for each overlay. When not 'random', should be a
+            float between 0 and 1 [default: 'random']
         overlay_class: The label of the class that overlays should be drawn from.
-            If None, draws from any class that is not the same class as the audio.
-            If creating a presence/absence classifier, set overlay_class
-            equal to the absence class label [default: None]
-        audio_sample_rate: resample audio to this sample rate; specify None to use original audio sample rate
-            default: 22050
-        debug: path to save img files, images are created from the tensor immediately before it is returned
-            default: None (do not save)
+            Must be specified if max_overlay_num > 0. If 'different', draws
+            overlays from any class that is not the same class as the audio. If
+            set to a class label, draws overlays from that class. When creating
+            a presence/absence classifier, set overlay_class equal to the
+            absence class label [default: None]
+        audio_sample_rate: resample audio to this sample rate; specify None to
+            use original audio sample rate [default: 22050]
+        debug: path to save img files, images are created from the tensor
+            immediately before it is returned. When None, does not save images.
+            [default: None]
 
     Output:
         Dictionary:


### PR DESCRIPTION
Allow users to choose an overlay class by label.

When getting a sample with overlay, the default behavior is to overlay the sample with a sample from a different class. This is the desired behavior for multi-class, single-target training. (This would also be the desired behavior for multi-target training, but we would have to create a class that modifies the targets for each sample. `SingleTargetAudioDataset` is conceptualized as a single-target-only Dataset.)

But for single-species classifiers, where the two classes represent "present" and "absent," the desired behavior is to never overlay with files from the present class. Otherwise, the absent class will contain a high rate of true presences. With this PR, this behavior can be accomplished by setting the overlay class to the absent class label, e.g. `0` if using numeric labels.