### PR TITLE
Separate train validation split from numeric labeling in data selection

### DIFF
--- a/opensoundscape/data_selection.py
+++ b/opensoundscape/data_selection.py
@@ -27,19 +27,20 @@ def expand_multi_labeled(input_df):
 
 
 def train_valid_split(
-    input_df, label_column="Labels", train_size=0.8, random_state=101
+    input_df, stratify_from_column="Labels", train_size=0.8, random_state=101
 ):
     """ Split a dataframe into train and validation dataframes
 
     Given an input dataframe with a labels column split each unique label into
     a train size and 1 - train_size for training and validation sets. If
-    label_column is `None` don't stratify.
+    stratify_from_column is `None` don't stratify.
 
     Args:
-        input_df:       A dataframe
-        label_column:   Name of the column that labels should come from [default: "Labels"]
-        train_size:     The decimal fraction to use for the training set [default: 0.8]
-        random_state:   The random state to use for train_test_split [default: 101]
+        input_df:               A dataframe
+        stratify_from_column:   Name of the column that labels should come from [default: "Labels"]
+                                - given `None` will not attempt stratified sampling
+        train_size:             The decimal fraction to use for the training set [default: 0.8]
+        random_state:           The random state to use for train_test_split [default: 101]
 
     Output:
         train_df:       A Dataframe containing the training set
@@ -48,14 +49,14 @@ def train_valid_split(
 
     df = copy(input_df)
 
-    if label_column:
-        assert label_column in df.columns
-        all_labels = df[label_column].unique()
+    if stratify_from_column:
+        assert stratify_from_column in df.columns
+        all_labels = df[stratify_from_column].unique()
 
         train_dfs = [None] * len(all_labels)
         valid_dfs = [None] * len(all_labels)
         for idx, label in enumerate(all_labels):
-            selection = df[df[label_column] == label]
+            selection = df[df[stratify_from_column] == label]
             train, valid = train_test_split(
                 selection, train_size=train_size, random_state=random_state
             )

--- a/opensoundscape/data_selection.py
+++ b/opensoundscape/data_selection.py
@@ -2,7 +2,7 @@
 import pandas as pd
 from sklearn.model_selection import train_test_split
 from copy import copy
-from itertools import repeat
+from itertools import repeat, count
 
 
 def expand_multi_labeled(input_df):
@@ -26,18 +26,17 @@ def expand_multi_labeled(input_df):
     return df.explode("Labels").reset_index(drop=True)
 
 
-def binary_train_valid_split(
-    input_df, label, label_column="Labels", train_size=0.8, random_state=101
+def train_valid_split(
+    input_df, label_column="Labels", train_size=0.8, random_state=101
 ):
-    """ Split a dataset into train and validation dataframes
+    """ Split a dataframe into train and validation dataframes
 
-    Given a Dataframe and a label in column "Labels" (singly labeled) generate
-    a train dataset with ~80% of each label and a valid dataset with the rest.
+    Given an input dataframe with a labels column split each unique label into
+    a train size and 1 - train_size for training and validation sets. If
+    label_column is `None` don't stratify.
 
     Args:
-        input_df:       A singly-labeled CSV file
-        label:          One of the labels in the column label_column to use as a positive
-                            label (1), all others are negative (0)
+        input_df:       A dataframe
         label_column:   Name of the column that labels should come from [default: "Labels"]
         train_size:     The decimal fraction to use for the training set [default: 0.8]
         random_state:   The random state to use for train_test_split [default: 101]
@@ -47,23 +46,77 @@ def binary_train_valid_split(
         valid_df:       A Dataframe containing the validation set
     """
 
-    assert label_column in input_df.columns
     df = copy(input_df)
 
-    all_labels = df[label_column].unique()
-    df["NumericLabels"] = df[label_column].apply(lambda x: 1 if x == label else 0)
+    if label_column:
+        assert label_column in df.columns
+        all_labels = df[label_column].unique()
 
-    train_dfs = [None] * len(all_labels)
-    valid_dfs = [None] * len(all_labels)
-    for idx, label in enumerate(all_labels):
-        selection = df[df[label_column] == label]
+        train_dfs = [None] * len(all_labels)
+        valid_dfs = [None] * len(all_labels)
+        for idx, label in enumerate(all_labels):
+            selection = df[df[label_column] == label]
+            train, valid = train_test_split(
+                selection, train_size=train_size, random_state=random_state
+            )
+            train_dfs[idx] = train
+            valid_dfs[idx] = valid
+    else:
         train, valid = train_test_split(
-            selection, train_size=train_size, random_state=random_state
+            df, train_size=train_size, random_state=random_state
         )
-        train_dfs[idx] = train
-        valid_dfs[idx] = valid
+        train_dfs = [train]
+        valid_dfs = [valid]
 
     return pd.concat(train_dfs), pd.concat(valid_dfs)
+
+
+def add_binary_numeric_labels(
+    input_df, label, input_column="Labels", output_column="NumericLabels"
+):
+    """ Add binary numeric labels to dataframe based on label
+
+    Given a dataframe and a label from input_column produce a new
+    dataframe with an output_column and a label map
+
+    Args:
+        input_df:       A dataframe
+        label:          The label to set to 1
+        input_column:   The column to read labels from
+        output_column:  The column to write numeric labels to
+
+    Output:
+        output_df:      A dataframe with an additional output_column
+        label_map:      A dictionary, keys are f"not_{label}" and f"{label}", values are 0 and 1
+    """
+
+    df = copy(input_df)
+    df[output_column] = df[input_column].apply(lambda x: 1 if x == label else 0)
+    label_map = {f"not_{label}": 0, f"{label}": 1}
+    return df, label_map
+
+
+def add_numeric_labels(input_df, input_column="Labels", output_column="NumericLabels"):
+    """ Add numeric labels to dataframe
+
+    Given a dataframe with input_column produce a new dataframe with an
+    output_column and a label map
+
+    Args:
+        input_df:       A dataframe
+        input_column:   The column to read labels from
+        output_column:  The column to write numeric labels to
+
+    Output:
+        output_df:      A dataframe with an additional output_column
+        label_map:      A dictionary, keys are the unique labels and monotonically increasing values starting at 0
+    """
+
+    df = copy(input_df)
+    unique_labels = df[input_column].unique()
+    label_map = {k: v for k, v in zip(unique_labels, count(0))}
+    df[output_column] = df[input_column].apply(lambda x: label_map[x])
+    return df, label_map
 
 
 def upsample(input_df, label_column="Labels", random_state=None):

--- a/opensoundscape/data_selection.py
+++ b/opensoundscape/data_selection.py
@@ -47,29 +47,19 @@ def train_valid_split(
         valid_df:       A Dataframe containing the validation set
     """
 
-    df = copy(input_df)
-
     if stratify_from_column:
-        assert stratify_from_column in df.columns
-        all_labels = df[stratify_from_column].unique()
-
-        train_dfs = [None] * len(all_labels)
-        valid_dfs = [None] * len(all_labels)
-        for idx, label in enumerate(all_labels):
-            selection = df[df[stratify_from_column] == label]
-            train, valid = train_test_split(
-                selection, train_size=train_size, random_state=random_state
-            )
-            train_dfs[idx] = train
-            valid_dfs[idx] = valid
-    else:
-        train, valid = train_test_split(
-            df, train_size=train_size, random_state=random_state
+        train_df, valid_df = train_test_split(
+            input_df,
+            train_size=train_size,
+            random_state=random_state,
+            stratify=input_df[stratify_from_column],
         )
-        train_dfs = [train]
-        valid_dfs = [valid]
+    else:
+        train_df, valid_df = train_test_split(
+            input_df, train_size=train_size, random_state=random_state
+        )
 
-    return pd.concat(train_dfs), pd.concat(valid_dfs)
+    return train_df, valid_df
 
 
 def add_binary_numeric_labels(

--- a/tests/test_data_selection.py
+++ b/tests/test_data_selection.py
@@ -9,37 +9,65 @@ def upsample_df():
     return pd.read_csv("tests/to_upsample.csv")
 
 
-def test_expand_multi_labeled_dataframe():
-    input_df = pd.DataFrame({"Labels": ["hello|world"]})
-    output_df = pd.DataFrame({"Labels": ["hello", "world"]})
-
-    assert selection.expand_multi_labeled(input_df).equals(output_df)
-
-
-def test_train_valid_binary_split():
-    input_df = pd.DataFrame(
+@pytest.fixture
+def input_dataframe():
+    return pd.DataFrame(
         {
             "Labels": [
-                "hello",
-                "world",
-                "hello",
-                "world",
-                "hello",
-                "world",
-                "hello",
-                "world",
-                "hello",
-                "world",
+                "foo",
+                "bar",
+                "baz",
+                "foo",
+                "bar",
+                "baz",
+                "foo",
+                "bar",
+                "baz",
+                "foo",
+                "bar",
+                "baz",
+                "foo",
+                "bar",
+                "baz",
             ]
         }
     )
 
-    train_df, valid_df = selection.binary_train_valid_split(input_df, "hello")
 
-    assert train_df[train_df["Labels"] == "hello"]["Labels"].count() == 4
-    assert valid_df[valid_df["Labels"] == "hello"]["Labels"].count() == 1
-    assert train_df[train_df["Labels"] == "world"]["Labels"].count() == 4
-    assert valid_df[valid_df["Labels"] == "world"]["Labels"].count() == 1
+def test_expand_multi_labeled_dataframe():
+    input_df = pd.DataFrame({"Labels": ["foo|bar"]})
+    output_df = pd.DataFrame({"Labels": ["foo", "bar"]})
+
+    assert selection.expand_multi_labeled(input_df).equals(output_df)
+
+
+def test_train_valid_basic_split(input_dataframe):
+    train_df, valid_df = selection.train_valid_split(input_dataframe)
+
+    assert train_df[train_df["Labels"] == "foo"]["Labels"].count() == 4
+    assert valid_df[valid_df["Labels"] == "foo"]["Labels"].count() == 1
+    assert train_df[train_df["Labels"] == "bar"]["Labels"].count() == 4
+    assert valid_df[valid_df["Labels"] == "bar"]["Labels"].count() == 1
+    assert train_df[train_df["Labels"] == "baz"]["Labels"].count() == 4
+    assert valid_df[valid_df["Labels"] == "baz"]["Labels"].count() == 1
+
+
+def test_add_binary_numeric_labels(input_dataframe):
+    output_column = "test_label"
+    output_df, label_map = selection.add_binary_numeric_labels(
+        input_dataframe, "foo", output_column=output_column
+    )
+    assert len(label_map) == 2
+    assert sorted(output_df[output_column].unique()) == [0, 1]
+
+
+def test_add_numeric_labels(input_dataframe):
+    output_column = "test_label"
+    output_df, label_map = selection.add_numeric_labels(
+        input_dataframe, output_column=output_column
+    )
+    assert len(label_map) == 3
+    assert sorted(output_df[output_column].unique()) == [0, 1, 2]
 
 
 def test_upsample_basic(upsample_df):


### PR DESCRIPTION
Initial API suggestion for splitting train/valid split from numeric labeling code