### PR TITLE
Avoid issues with non-integer classes passed

### DIFF
--- a/opensoundscape/torch/train.py
+++ b/opensoundscape/torch/train.py
@@ -99,10 +99,15 @@ def train(
     model.to(device)
 
     # Model training
-    stats = []
-    classes = list(train_dataset.label_dict.keys())
-    for epoch in range(epochs):
+    # Clases should be integer values
+    try:
+        classes = [int(x) for x in train_dataset.label_dict.keys()]
+    except:
+        raise ValueError(
+            f"The classes should be integers! Got {train_dataset.label_dict.keys()}"
+        )
 
+    for epoch in range(epochs):
         # Train model
         if print_logging:
             print(f"Epoch {epoch}")


### PR DESCRIPTION
I ran into an issue where my label dictionary was flipped, i.e.

```
name: 0
...
```

versus

```
0: name
```

This code ensures that a user passes us integer classes and it avoids a weird error.
