### PR TITLE
Insert UTC timezone in hex_to_utc

### DIFF
--- a/opensoundscape/helpers.py
+++ b/opensoundscape/helpers.py
@@ -62,7 +62,7 @@ def hex_to_time(s):
     from datetime import datetime
 
     sec = int(s, 16)
-    timestamp = datetime.utcfromtimestamp(sec)
+    timestamp = datetime.utcfromtimestamp(sec).replace(tzinfo=pytz.utc)
     return timestamp
 
 


### PR DESCRIPTION

Let's say we use this function to convert from hexadecimal to UTC. Start with a hexadecimal number that represents 07:59:10 UTC on July 21:
```
> t = hex_to_time('5F16A04E')
datetime.datetime(2020, 7, 21, 7, 59, 10)
```

Current behavior: if we attempt to convert from UTC to Eastern the time doesn't change. Because `t` doesn't already have a timezone associated with it, the package interprets `t` as already being in my local timezone (Eastern):
```
> t.astimezone(tz=pytz.timezone("US/Eastern"))
datetime.datetime(2020, 7, 21, 7, 59, 10, tzinfo=<DstTzInfo 'US/Eastern' EDT-1 day, 20:00:00 DST>)
```


Behavior with this pull request: `hex_to_utc` now inserts the UTC timezone into `t`. That way, converting to a different timezone produces the expected behavior, returning a time that is 4 hours before the hexadecimal time.
```
> t = hex_to_time('5F16A04E')
> t.astimezone(tz=pytz.timezone("US/Eastern"))
datetime.datetime(2020, 7, 21, 3, 59, 10, tzinfo=<DstTzInfo 'US/Eastern' EDT-1 day, 20:00:00 DST>)
```
