### PR TITLE
Copy spectrogram in limit_db_range

### DIFF
--- a/opensoundscape/spectrogram.py
+++ b/opensoundscape/spectrogram.py
@@ -191,7 +191,10 @@ class Spectrogram:
             Returns:
                 Spectrogram object with db range applied
         """
-        _spec = self.spectrogram
+        if not max_db > min_db:
+            raise ValueError(f"max_db must be greater than min_db (got max_db={max_db} and min_db={min_db})")
+
+        _spec = self.spectrogram.copy()
 
         _spec[_spec > max_db] = max_db
         _spec[_spec < min_db] = min_db

--- a/opensoundscape/spectrogram.py
+++ b/opensoundscape/spectrogram.py
@@ -192,7 +192,9 @@ class Spectrogram:
                 Spectrogram object with db range applied
         """
         if not max_db > min_db:
-            raise ValueError(f"max_db must be greater than min_db (got max_db={max_db} and min_db={min_db})")
+            raise ValueError(
+                f"max_db must be greater than min_db (got max_db={max_db} and min_db={min_db})"
+            )
 
         _spec = self.spectrogram.copy()
 


### PR DESCRIPTION
Without this change, using the `limit_db_range()` method modifies the spectrogram of the instance. This change also enforces min_db < max_db.