### PR TITLE
Change default loss functions

### DIFF
--- a/opensoundscape/torch/loss.py
+++ b/opensoundscape/torch/loss.py
@@ -28,7 +28,7 @@ class CrossEntropyLoss_hot(nn.CrossEntropyLoss):
         super(CrossEntropyLoss_hot, self).__init__()
 
     def forward(self, input, target):
-        if not (x.sum(1).all() and x.sum(1).max() == 1):
+        if not (target.sum(1).all() and target.sum(1).max() == 1):
             raise ValueError("labels must be single-target for CrossEntropyLoss")
         target = target.argmax(1)
         return super(CrossEntropyLoss_hot, self).forward(input, target)

--- a/opensoundscape/torch/loss.py
+++ b/opensoundscape/torch/loss.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 
 
 class BCEWithLogitsLoss_hot(nn.BCEWithLogitsLoss):
-    """use nn.BCEWithLogitsLoss for one-hot labels
+    """use pytorch's nn.BCEWithLogitsLoss for one-hot labels
     by simply converting y from long to float"""
 
     def __init__(self):
@@ -15,6 +15,23 @@ class BCEWithLogitsLoss_hot(nn.BCEWithLogitsLoss):
     def forward(self, input, target):
         target = target.float()
         return super(BCEWithLogitsLoss_hot, self).forward(input, target)
+
+
+class CrossEntropyLoss_hot(nn.CrossEntropyLoss):
+    """use pytorch's nn.CrossEntropyLoss for one-hot labels
+    by converting labels from 1-hot to integer labels
+
+    throws a ValueError if labels are not one-hot
+    """
+
+    def __init__(self):
+        super(CrossEntropyLoss_hot, self).__init__()
+
+    def forward(self, input, target):
+        if not (x.sum(1).all() and x.sum(1).max() == 1):
+            raise ValueError("labels must be single-target for CrossEntropyLoss")
+        target = target.argmax(1)
+        return super(CrossEntropyLoss_hot, self).forward(input, target)
 
 
 def reduce_loss(loss, reduction):


### PR DESCRIPTION
This branch changed default loss functions to be more "correct" as I best understand:
- "binary" (2 class) classification or single-target models use Cross Entropy Loss, which is log softmax -> NLL Loss
- multitarget models use Binary Cross Entropy "with logits" loss, which is a sigmoid layer -> NLL Loss (it does not perform softmax because it is multi-target, ie can predict multiple classes, so instead it gets values from -inf,inf to 0,1 using sigmoid)

It also creates a subclass of PytorchModel for using ResampleLoss. This allows you to easily use ResampleLoss with any architecture without having to write your own subclass. Usage is simply `model = CnnResampleLoss(architecture,classes)` . 

Similarly, added a resample loss class for InceptionV3