### PR TITLE
Issue 364 dont resample

### DIFF
--- a/opensoundscape/preprocess/actions.py
+++ b/opensoundscape/preprocess/actions.py
@@ -207,7 +207,7 @@ class SpectrogramBandpass(BaseAction):
     Args:
         min_f: low frequency in Hz for bandpass
         max_f: high frequency in Hz for bandpass
-
+        out_of_bounds_ok: if False, raises error if min or max beyond spec limits
     """
 
     def go(self, spectrogram):

--- a/opensoundscape/preprocess/preprocessors.py
+++ b/opensoundscape/preprocess/preprocessors.py
@@ -227,7 +227,7 @@ class AudioToSpectrogramPreprocessor(BasePreprocessor):
         self.pipeline.append(self.actions.to_spec)
 
         self.actions.bandpass = actions.SpectrogramBandpass(
-            min_f=0, max_f=10000, out_of_bounds_ok=False
+            min_f=0, max_f=11025, out_of_bounds_ok=False
         )
         self.pipeline.append(self.actions.bandpass)
 

--- a/opensoundscape/spectrogram.py
+++ b/opensoundscape/spectrogram.py
@@ -310,7 +310,7 @@ class Spectrogram:
 
         return self.__class__(_spec, self.frequencies, self.times, self.decibel_limits)
 
-    def bandpass(self, min_f, max_f):
+    def bandpass(self, min_f, max_f, out_of_bounds_ok=True):
         """extract a frequency band from a spectrogram
 
         crops the 2-d array of the spectrograms to the desired frequency range
@@ -318,6 +318,9 @@ class Spectrogram:
         Args:
             min_f: low frequency in Hz for bandpass
             max_f: high frequency in Hz for bandpass
+            out_of_bounds_ok: (bool) if False, raises ValueError if min_f or max_f
+                are not within the range of the original spectrogram's frequencies
+                [default: True]
 
         Returns:
             bandpassed spectrogram object
@@ -328,6 +331,14 @@ class Spectrogram:
             raise ValueError(
                 f"min_f must be less than max_f (got min_f {min_f}, max_f {max_f}"
             )
+
+        if not out_of_bounds_ok:
+            # self.frequencies fully coveres the spec's frequency range
+            if min_f < min(self.frequencies) or max_f > max(self.frequencies):
+                raise ValueError(
+                    "with out_of_bounds_ok=False, min_f and max_f must fall"
+                    "inside the range of self.frequencies"
+                )
 
         # find indices of the frequencies in spec_freq closest to min_f and max_f
         lowest_index = np.abs(self.frequencies - min_f).argmin()

--- a/tests/test_spectrogram.py
+++ b/tests/test_spectrogram.py
@@ -88,6 +88,22 @@ def test_bandpass_spectrogram():
     ).bandpass(2, 4)
 
 
+def test_bandpass_spectrogram_out_of_bounds():
+    with pytest.raises(ValueError):
+        Spectrogram(
+            np.zeros((5, 10)),
+            np.linspace(0, 10, 5),
+            np.linspace(0, 10, 10),
+            (-100, -20),
+        ).bandpass(0, 11, out_of_bounds_ok=False)
+
+
+def test_bandpass_spectrogram_not_out_of_bounds():
+    Spectrogram(
+        np.zeros((5, 10)), np.linspace(0, 10, 5), np.linspace(0, 10, 10), (-100, -20)
+    ).bandpass(0.0, 10.0, out_of_bounds_ok=False)
+
+
 def test_bandpass_spectrogram_bad_limits():
     with pytest.raises(ValueError):
         Spectrogram(


### PR DESCRIPTION
This branch changes the default preprocessing behavior of AudioToSpectrogramPreprocessor (and it's children including CnnPreprocessor):
- no audio resampling is performed
- spectrograms are bandpassed to 0-10kHz
- if spectrogram does not cover the bandpassing range of 0-10kHz, raises an error

The primary reason for this change is that audio resampling increases preprocessing time by ~5x and is usually unnecessary. 