### PR TITLE
Issue 294 per-class thresholds for binary predictions

### DIFF
--- a/opensoundscape/torch/models/cnn.py
+++ b/opensoundscape/torch/models/cnn.py
@@ -608,7 +608,7 @@ class PytorchModel(BaseModule):
                 - None: do not create or return binary predictions
                 [default: None]
             threshold:
-                prediction threshold for sigmoid scores. Only relevant when
+                prediction threshold(s) for sigmoid scores. Only relevant when
                 binary_preds == 'multi_target'
             error_log:
                 if not None, saves a list of files that raised errors to

--- a/opensoundscape/torch/models/utils.py
+++ b/opensoundscape/torch/models/utils.py
@@ -5,6 +5,7 @@ from opensoundscape.torch.sampling import ClassAwareSampler, ImbalancedDatasetSa
 from torch.utils.data import DataLoader
 from torch.nn.functional import softmax
 import pandas as pd
+import numpy as np
 
 
 class BaseModule(nn.Module):
@@ -241,7 +242,9 @@ def tensor_binary_predictions(scores, mode, threshold=None):
         if threshold is None:
             raise ValueError(f"threshold must be specified for multi_target prediction")
         # predict 0 or 1 based on a fixed threshold
-        try:
+        elif type(threshold) in [float, np.float32, np.float64, int]:
+            preds = torch.sigmoid(scores) >= threshold
+        elif type(threshold) in [np.array, list, torch.Tensor, tuple]:
             if len(threshold) == 1 or len(threshold) == len(scores[0]):
                 # will make predictions for either a single threshold value or list of class-specific threshold values
                 preds = torch.sigmoid(scores) >= torch.tensor(threshold)
@@ -249,8 +252,6 @@ def tensor_binary_predictions(scores, mode, threshold=None):
                 raise ValueError(
                     f"threshold must be a single value, or have the same number of values as there are classes"
                 )
-        except TypeError:  # happens if threshold passed is a float
-            preds = torch.sigmoid(scores) >= torch.tensor(threshold)
 
     elif mode is None:
         preds = torch.Tensor([])

--- a/opensoundscape/torch/models/utils.py
+++ b/opensoundscape/torch/models/utils.py
@@ -243,10 +243,11 @@ def tensor_binary_predictions(scores, mode, threshold=None):
         # predict 0 or 1 based on a fixed threshold
         try:
             if len(threshold) == 1 or len(threshold) == len(scores[0]):
+                # will make predictions for either a single threshold value or list of class-specific threshold values
                 preds = torch.sigmoid(scores) >= torch.tensor(threshold)
             else:
                 raise ValueError(
-                    f"threshold must have the same number of values as there are classes"
+                    f"threshold must be a single value, or have the same number of values as there are classes"
                 )
         except TypeError:  # happens if threshold passed is a float
             preds = torch.sigmoid(scores) >= torch.tensor(threshold)

--- a/opensoundscape/torch/models/utils.py
+++ b/opensoundscape/torch/models/utils.py
@@ -245,8 +245,10 @@ def tensor_binary_predictions(scores, mode, threshold=None):
             if len(threshold) == 1 or len(threshold) == len(scores[0]):
                 preds = torch.sigmoid(scores) >= torch.tensor(threshold)
             else:
-                raise ValueError(f"threshold must have the same number of values as there are classes")
-        except TypeError: #happens if threshold passed is a float
+                raise ValueError(
+                    f"threshold must have the same number of values as there are classes"
+                )
+        except TypeError:  # happens if threshold passed is a float
             preds = torch.sigmoid(scores) >= torch.tensor(threshold)
 
     elif mode is None:

--- a/tests/test_cnn_utils.py
+++ b/tests/test_cnn_utils.py
@@ -23,4 +23,5 @@ def test_tensor_binary_predictions():
     with pytest.raises(ValueError):
         tensor_binary_predictions(scores, mode="wrong", threshold=0.5)
     with pytest.raises(ValueError):
+        # must raise ValueError because threshold is length 2, but there are 3 classes
         tensor_binary_predictions(scores, mode="multi_target", threshold=[0.5, 0])

--- a/tests/test_cnn_utils.py
+++ b/tests/test_cnn_utils.py
@@ -1,0 +1,15 @@
+from opensoundscape.torch.models.utils import (
+    tensor_binary_predictions)
+
+import pytest
+import torch
+
+def test_tensor_binary_predictions():
+    scores = torch.stack((torch.arange(-5,5,1), torch.arange(-10,0,1)))
+    assert torch.sum(tensor_binary_predictions(scores, mode = "multi_target", threshold = 0)) == 20
+    assert torch.sum(tensor_binary_predictions(scores, mode = "multi_target", threshold = 1.1)) == 0
+    assert torch.sum(tensor_binary_predictions(scores, mode = "multi_target", threshold = [1,0]*5)) == 10
+    with pytest.raises(ValueError):
+        tensor_binary_predictions(scores, mode = "wrong", threshold = 0.5)
+    with pytest.raises(ValueError):
+        tensor_binary_predictions(scores, mode = "multi_target", threshold = [0.5,0])

--- a/tests/test_cnn_utils.py
+++ b/tests/test_cnn_utils.py
@@ -1,15 +1,26 @@
-from opensoundscape.torch.models.utils import (
-    tensor_binary_predictions)
+from opensoundscape.torch.models.utils import tensor_binary_predictions
 
 import pytest
 import torch
 
+
 def test_tensor_binary_predictions():
-    scores = torch.stack((torch.arange(-5,5,1), torch.arange(-10,0,1)))
-    assert torch.sum(tensor_binary_predictions(scores, mode = "multi_target", threshold = 0)) == 20
-    assert torch.sum(tensor_binary_predictions(scores, mode = "multi_target", threshold = 1.1)) == 0
-    assert torch.sum(tensor_binary_predictions(scores, mode = "multi_target", threshold = [1,0]*5)) == 10
+    scores = torch.stack((torch.arange(-5, 5, 1), torch.arange(-10, 0, 1)))
+    assert (
+        torch.sum(tensor_binary_predictions(scores, mode="multi_target", threshold=0))
+        == 20
+    )
+    assert (
+        torch.sum(tensor_binary_predictions(scores, mode="multi_target", threshold=1.1))
+        == 0
+    )
+    assert (
+        torch.sum(
+            tensor_binary_predictions(scores, mode="multi_target", threshold=[1, 0] * 5)
+        )
+        == 10
+    )
     with pytest.raises(ValueError):
-        tensor_binary_predictions(scores, mode = "wrong", threshold = 0.5)
+        tensor_binary_predictions(scores, mode="wrong", threshold=0.5)
     with pytest.raises(ValueError):
-        tensor_binary_predictions(scores, mode = "multi_target", threshold = [0.5,0])
+        tensor_binary_predictions(scores, mode="multi_target", threshold=[0.5, 0])


### PR DESCRIPTION
Resolves #294 by adding per-class thresholds for use when generating binary predictions on the output of a cnn.PytorchModel.forward() call.