### PR TITLE
add from_checkpoint() method to Resnet18Multiclass

### DIFF
--- a/opensoundscape/torch/models/cnn.py
+++ b/opensoundscape/torch/models/cnn.py
@@ -1039,6 +1039,17 @@ class Resnet18Multiclass(CnnResampleLoss):
         param_dict["classifier"]["params"] = self.network.classifier.parameters()
         return self.optimizer_cls(param_dict.values())
 
+    @classmethod
+    def from_checkpoint(cls, path):
+        # need to get classes first to initialize the model object
+        try:
+            classes = torch.load(path)["classes"]
+        except RuntimeError:  # model was saved on GPU and now on CPU
+            classes = torch.load(path, map_location=torch.device("cpu"))["classes"]
+        model_obj = cls(classes)
+        model_obj.load(path)
+        return model_obj
+
 
 class Resnet18Binary(PytorchModel):
     """Subclass of PytorchModel with Resnet18 architecture

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -62,6 +62,10 @@ def test_train(train_dataset):
     model_path = Path("tests/models/binary/best.model")
     binary.save(model_path)
     assert model_path.exists()
+
+    # check that from_checkpoint works
+    Resnet18Multiclass.from_checkpoint(model_path)
+
     shutil.rmtree("tests/models/binary")
 
 
@@ -79,6 +83,10 @@ def test_train_multiclass(train_dataset):
     model_path = Path("tests/models/multiclass/best.model")
     model.save(model_path)
     assert model_path.exists()
+
+    # check that from_checkpoint works
+    Resnet18Multiclass.from_checkpoint(model_path)
+
     shutil.rmtree("tests/models/multiclass/")
 
 


### PR DESCRIPTION
I think it was just oversight that this method did not already exist. 

I currently have a branch open `issue_411_randinit` which will change Resnet18Multiclass and Resnet18Binary to be subclasses of PyTorch model (or CnnResampleLoss), which will remove the need for local implementation of resnet etc, and will resolve #411 because initialization will be the same as PyTorchModel. The only difference between these classes and the equivalent resnet18 created with PytorchModel/CnnResampleLoss will be the separation of feat/clf blocks which allows separate optimization parameters for each. This suggests we might want to rename the classes, and that the standard tutorials on cnns should use PytorchModel or CnnResampleLoss. 