### PR TITLE
update init files to allow top-level import of opensoundscape

### DIFF
--- a/opensoundscape/__init__.py
+++ b/opensoundscape/__init__.py
@@ -1,1 +1,17 @@
 __version__ = "0.6.0"
+
+from . import annotations
+from . import audio_tools
+from . import audio
+from . import audiomoth
+from . import data_selection
+from . import helpers
+from . import localization
+from . import metrics
+from . import ribbit
+from . import signal
+from . import spectrogram
+from . import taxa
+from . import torch
+from . import preprocess
+from . import resources

--- a/opensoundscape/preprocess/__init__.py
+++ b/opensoundscape/preprocess/__init__.py
@@ -1,0 +1,5 @@
+from . import actions
+from . import img_augment
+from . import preprocessors
+from . import tensor_augment
+from . import utils

--- a/opensoundscape/torch/__init__.py
+++ b/opensoundscape/torch/__init__.py
@@ -1,0 +1,6 @@
+from . import grad_cam
+from . import loss
+from . import safe_dataset
+from . import sampling
+from . import architectures
+from . import models

--- a/opensoundscape/torch/architectures/__init__.py
+++ b/opensoundscape/torch/architectures/__init__.py
@@ -1,0 +1,3 @@
+from . import cnn_architectures
+from . import resnet
+from . import utils

--- a/opensoundscape/torch/models/__init__.py
+++ b/opensoundscape/torch/models/__init__.py
@@ -1,0 +1,2 @@
+from . import cnn
+from . import utils


### PR DESCRIPTION
This enable the syntax:
```
import opensoundscape as opso
opso.audio.Audio(...)
```
which would fail before. 
We will need to update init files any time files change names/locations 
or are added/deleted