### PR TITLE
modify make_clip_df to handle a single filepath string nicely

### DIFF
--- a/opensoundscape/helpers.py
+++ b/opensoundscape/helpers.py
@@ -249,6 +249,10 @@ def make_clip_df(files, clip_duration, clip_overlap=0, final_clip=None):
 
     import librosa
 
+    # if user passes a string filepath, will convert it to list
+    if isinstance(files, str):
+        files = [files]
+
     clip_dfs = []
     for f in files:
         t = librosa.get_duration(filename=f)

--- a/opensoundscape/helpers.py
+++ b/opensoundscape/helpers.py
@@ -249,9 +249,10 @@ def make_clip_df(files, clip_duration, clip_overlap=0, final_clip=None):
 
     import librosa
 
-    # if user passes a string filepath, will convert it to list
     if isinstance(files, str):
-        files = [files]
+        raise TypeError(
+            "make_clip_df expects a list of files, it looks like you passed it a string"
+        )
 
     clip_dfs = []
     for f in files:


### PR DESCRIPTION
This closes #456. I'm not sure if it is necessary. It may be better to warn the user they passed a string, instead of a list. Or it may be better to not address this issue at all.