### PR TITLE
Minor updates to annotation tutorial

### DIFF
--- a/docs/tutorials/annotation_tutorial.ipynb
+++ b/docs/tutorials/annotation_tutorial.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Manipulating audio annotations\n",
     "\n",
-    "This notebook demonstrates how to use the `annotations` module of OpenSoundscape to\n",
+    "This notebook demonstrates how to use the `annotations` module of OpenSoundscape to:\n",
     "\n",
     "- load annotations from Raven files\n",
     "\n",
@@ -40,7 +40,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### download example files\n",
+    "### Download example files\n",
     "Run the code below to download a set of example audio and raven annotations files for this tutorial. "
    ]
   },
@@ -57,8 +57,8 @@
       "                                 Dload  Upload   Total   Spent    Left  Speed\n",
       "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\n",
       "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\n",
-      "100     7    0     7    0     0      6      0 --:--:--  0:00:01 --:--:--     0\n",
-      "100 5432k  100 5432k    0     0  2393k      0  0:00:02  0:00:02 --:--:-- 11.0M\n"
+      "100     7    0     7    0     0      4      0 --:--:--  0:00:01 --:--:--     7\n",
+      "100 5432k  100 5432k    0     0  2166k      0  0:00:02  0:00:02 --:--:-- 2166k\n"
      ]
     },
     {
@@ -90,7 +90,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can use the BoxedAnnotation class's `from_raven_file` method to load a Raven txt file into OpenSoundscape. This table contains the frequency and time limits of rectangular \"boxes\" representing each annotation that was created in Raven. \n",
+    "We can use the BoxedAnnotation class's `from_raven_file` method to load a Raven .txt file into OpenSoundscape. This table contains the frequency and time limits of rectangular \"boxes\" representing each annotation that was created in Raven. \n",
     "\n",
     "Note that we need to specify the name of the column containing annotations, since it can be named anything in Raven. The column will be renamed to \"annotation\". \n",
     "\n",
@@ -112,7 +112,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "let's look at a spectrogram of the audio file to see what we're working with"
+    "Let's look at a spectrogram of the audio file to see what we're working with."
    ]
   },
   {
@@ -145,7 +145,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "now, let's load the annotations from the Raven annotation file"
+    "Now, let's load the annotations from the Raven annotation file."
    ]
   },
   {
@@ -283,7 +283,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "we could instead choose to load it with only the necessary columns, plus the \"Notes\" column"
+    "Note: if you **do not have an annotation column**, e.g.,  if you are annotating the sounds of a single species, the function above doesn't work in the current version of OpenSoundscape. A workaround is to use `annotation_column='Channel'`, in which case, the \"annotation\" of your file will be equal to the channel number. If your recordings are single-channel, then the \"class\" of every annotation will just be the number 1."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We could instead choose to only load the necessary columns (`start_time`, `end_time`, `low_f`, `high_f`, and `annotation`) using the `keep_extra_columns=None`. \n",
+    "\n",
+    "In this example, we use `keep_extra_columns=['Notes']` to keep only the Notes column."
    ]
   },
   {
@@ -396,7 +405,7 @@
     "## Convert or correct annotations\n",
     "We can provide a DataFrame (e.g., from a .csv file) or a dictionary to convert original values to new values. \n",
     "\n",
-    "Let's load up a little csv file that specifies a set of conversions we'd like to make. The csv file should have two columns, but it doesn't matter what they are called. If you create a table in Microsoft Excel, you can export it to a .csv file to use it as your conversion table. "
+    "Let's load up a little .csv file that specifies a set of conversions we'd like to make. The .csv file should have two columns, but it doesn't matter what they are called. If you create a table in Microsoft Excel, you can export it to a .csv file to use it as your conversion table. "
    ]
   },
   {
@@ -458,7 +467,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "alternatively, we could simply write a Python dictionary for the conversion table. For instance:"
+    "Alternatively, we could simply write a Python dictionary for the conversion table. For instance:"
    ]
   },
   {
@@ -477,9 +486,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "now, we can apply the conversions in the table to our annotations.\n",
+    "Now, we can apply the conversions in the table to our annotations.\n",
     "\n",
-    "This will create a new BoxedAnnotations object rather than modifying the original object (\"out of place operation\")"
+    "This will create a new BoxedAnnotations object rather than modifying the original object (an \"out of place operation\")."
    ]
   },
   {
@@ -620,9 +629,9 @@
    "metadata": {},
    "source": [
     "### View a subset of annotations\n",
-    "Specify a list of classes to include in the subset\n",
+    "We can specify a list of classes to view annotations of.\n",
     "\n",
-    "for example, we can subset to only annotations marked as '?'"
+    "For example, we can subset to only annotations marked as \"?\" - perhaps we're interested in looking at these annotations in Raven again to determine what class they really were."
    ]
   },
   {
@@ -693,8 +702,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### saving annotations to Raven-compatible file\n",
-    "We can always save our BoxedAnnotations object to a Raven-compatible txt file, which can be opened in Raven along with an audio file just like the files Raven creates itself. You must specify a path for the save file that ends with `.txt`. "
+    "### Saving annotations to Raven-compatible file\n",
+    "We can always save our BoxedAnnotations object to a Raven-compatible .txt file, which can be opened in Raven along with an audio file just like the .txt files Raven creates itself. You must specify a path for the save file that ends with `.txt`. "
    ]
   },
   {
@@ -710,16 +719,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Splitting annotations along with audio\n",
+    "## Split an audio clip and its annotations\n",
     "Often, we want to train or validate models on short audio segments (e.g., 5 seconds) rather than on long files (e.g., 2 hours). \n",
     "\n",
-    "We can accomplish this in three ways: \n",
+    "To do this, we need two things:\n",
     "\n",
-    "(1) Split the annotations (`.one_hot_labels_like()`) using the DataFrame returned by `Audio.split()` (this dataframe includes the start and end times of each clip)\n",
+    "* A saved set of short audio clips\n",
     "\n",
-    "(2) Create a dataframe of start and end times, and split the audio accordingly \n",
+    "* A table that associates each split audio clip with the annotations in the clip (e.g., which species, if any, are present in each clip). Usually these are in \"one-hot encoding\" form (see explanation below).\n",
     "\n",
-    "(3) directly split the labels with `.one_hot_clip_labels()`, using splitting parameters that match Audio.split()\n",
+    "We can use OpenSoundscape to split annotations, and optionally, the audio clips associated with the annotations, in three ways: \n",
+    "\n",
+    "**Splitting both Audio and annotations:**\n",
+    "\n",
+    "1. Split the audio first using `Audio.split()`, then use the DataFrame of clip start/end times returned by this function to split the annotations using `BoxedAnnotations.one_hot_labels_like()`\n",
+    "\n",
+    "**Splitting annotations only:**\n",
+    "\n",
+    "2. Use `BoxedAnnotations.one_hot_clip_labels()` to split the annotations in one step\n",
+    "\n",
+    "3. Create a DataFrame of clip start/end times similar to the one generated by `Audio.split()`, then use it to split the annotations using `BoxedAnnotations.one_hot_labels_like()`\n",
     "\n",
     "All three methods are demonstrated below."
    ]
@@ -728,9 +747,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 1. Split Audio object, then split annotations to match\n",
+    "***What is one-hot encoding?***\n",
     "\n",
-    "After splitting audio with audio.split(), we'll use BoxedAnnotation's `one_hot_labels_like()` function to extract the labels for each audio clip. This function requires that we specify the minimum overlap of the label (in seconds) with the clip for the clip to be labeled positive. We also specify the list of classes for one-hot labels (if we give classes=None, it will make a column for every unique label in the annotations)."
+    "The functions below demonstrate the creation of one-hot encoded labels. \n",
+    "\n",
+    "This machine learning term, \"one-hot encoding,\" refers to a way to format a table of labels in which:\n",
+    "* Each row represents a single sample, like a single 5-second long clip\n",
+    "* Each column represents a single possible class (e.g. one of multiple species)\n",
+    "* A \"0\" in a row and column means that in that sample, the class is not present\n",
+    "* A \"1\" is \"hot,\" meaning that in that sample, the class *IS* present.\n",
+    "\n",
+    "For example, let's say we had a 15-second audio clip that we were splitting into three 5s clips. Let's say we are training a classifier to identify coyotes and dogs, and we labeled the clip and found:\n",
+    "* a coyote howled from 2.5 to 4 seconds into the clip (so, only the first clip contains it)\n",
+    "* a dog barked from 4 seconds to 10 seconds into the clip (so, both the first and second clips contain it)\n",
+    "* and there was silence for the last 5 seconds of the clip (so, the third clip has neither coyotes nor dogs in it).\n",
+    "\n",
+    "The one-hot encoded labels file for this example would look like:"
    ]
   },
   {
@@ -759,53 +791,43 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th>GWWA_song</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>start_time</th>\n",
        "      <th>end_time</th>\n",
-       "      <th></th>\n",
+       "      <th>COYOTE</th>\n",
+       "      <th>DOG</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>0.0</th>\n",
-       "      <th>5.0</th>\n",
-       "      <td>1.0</td>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>5</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>5.0</th>\n",
-       "      <th>10.0</th>\n",
-       "      <td>1.0</td>\n",
+       "      <th>1</th>\n",
+       "      <td>5</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>10.0</th>\n",
-       "      <th>15.0</th>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15.0</th>\n",
-       "      <th>20.0</th>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>20.0</th>\n",
-       "      <th>25.0</th>\n",
-       "      <td>1.0</td>\n",
+       "      <th>2</th>\n",
+       "      <td>10</td>\n",
+       "      <td>15</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                     GWWA_song\n",
-       "start_time end_time           \n",
-       "0.0        5.0             1.0\n",
-       "5.0        10.0            1.0\n",
-       "10.0       15.0            0.0\n",
-       "15.0       20.0            0.0\n",
-       "20.0       25.0            1.0"
+       "   start_time  end_time  COYOTE  DOG\n",
+       "0           0         5       1    1\n",
+       "1           5        10       0    1\n",
+       "2          10        15       0    0"
       ]
      },
      "execution_count": 12,
@@ -814,33 +836,216 @@
     }
    ],
    "source": [
-    "# load the Audio and Annotations\n",
-    "audio = Audio.from_file(audio_file)\n",
-    "annotations = BoxedAnnotations.from_raven_file(annotation_file,annotation_column='Species')\n",
-    "\n",
-    "# split the audio into 5 second clips with no overlap (we use _ because we don't really need to save the audio clip objects for this demo)\n",
-    "_, clip_df = audio.split(clip_duration=5.0, clip_overlap=0.0)\n",
-    "\n",
-    "labels_df = annotations.one_hot_labels_like(clip_df,min_label_overlap=0.25,classes=['GWWA_song'])\n",
-    "\n",
-    "#the returned dataframe of one-hot labels (0/1 for each class and each clip) has rows corresponding to each audio clip\n",
-    "labels_df.head()"
+    "pd.DataFrame({\n",
+    "    \"start_time\":[0, 5, 10],\n",
+    "    \"end_time\":[5, 10, 15],\n",
+    "    \"COYOTE\":[1, 0, 0],\n",
+    "    \"DOG\":[1, 1, 0]\n",
+    "})"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2. Split annotations into labels (without audio splitting)\n",
+    "### 1. Split Audio object, then split annotations to match\n",
     "\n",
-    "The function in the previous example, `one_hot_labels_like()`, splits the labels according to start and end times from a DataFrame. But how would we get that DataFrame if we aren't actually splitting Audio files? \n",
+    "First, split an Audio object with `Audio.split()`, which returns two things:\n",
     "\n",
-    "We can create the dataframe with a helper function that takes the same splitting parameters as Audio.split(). Notice that we need to specify one additional parameter: the entire duration to be split (`full_duration`).\n"
+    "1. A list of audio clip objects\n",
+    "\n",
+    "2. A dataframe of start/end times"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>start_time</th>\n",
+       "      <th>end_time</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>5.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>5.0</td>\n",
+       "      <td>10.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>10.0</td>\n",
+       "      <td>15.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>15.0</td>\n",
+       "      <td>20.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>20.0</td>\n",
+       "      <td>25.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   start_time  end_time\n",
+       "0         0.0       5.0\n",
+       "1         5.0      10.0\n",
+       "2        10.0      15.0\n",
+       "3        15.0      20.0\n",
+       "4        20.0      25.0"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Load the Audio and Annotations\n",
+    "audio = Audio.from_file(audio_file)\n",
+    "annotations = BoxedAnnotations.from_raven_file(annotation_file, annotation_column='Species')\n",
+    "\n",
+    "# Split the audio into 5 second clips with no overlap (we use _ because we don't really need to save the audio clip objects for this demo)\n",
+    "_, clip_df = audio.split(\n",
+    "    clip_duration=5.0, # How long each clip should be\n",
+    "    clip_overlap=0.0 # By how many seconds each subsequent clip should overlap\n",
+    ")\n",
+    "clip_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Different overlap and duration settings produce different results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>start_time</th>\n",
+       "      <th>end_time</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>3.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>5.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>4.0</td>\n",
+       "      <td>7.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>6.0</td>\n",
+       "      <td>9.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>8.0</td>\n",
+       "      <td>11.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   start_time  end_time\n",
+       "0         0.0       3.0\n",
+       "1         2.0       5.0\n",
+       "2         4.0       7.0\n",
+       "3         6.0       9.0\n",
+       "4         8.0      11.0"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Split the audio into 5 second clips with no overlap (we use _ because we don't really need to save the audio clip objects for this demo)\n",
+    "_, clip_df_short_with_overlaps = audio.split(\n",
+    "    clip_duration=3.0, # How long each clip should be\n",
+    "    clip_overlap=1.0 # By how many seconds each subsequent clip should overlap\n",
+    ")\n",
+    "clip_df_short_with_overlaps.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, extract annotations for each clip using `BoxedAnnotations.one_hot_labels_like()`. \n",
+    "\n",
+    "This function requires that we specify the minimum overlap of the label (in seconds) with the clip for the clip to be labeled positive. It also requires that we either (1) specify the list of classes for one-hot labels or (2) specify `classes=None`, which will make a column for every unique label in the annotations. In this example, that would include a \"?\" class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -913,18 +1118,18 @@
        "20.0       25.0            1.0"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# generate clip start/end time DataFrame\n",
-    "from opensoundscape.helpers import generate_clip_times_df\n",
-    "clip_df = generate_clip_times_df(full_duration=60,clip_duration=5.0, clip_overlap=0.0)\n",
-    "\n",
-    "#we can use the clip_df to split the Annotations in the same way as before\n",
-    "labels_df = annotations.one_hot_labels_like(clip_df,min_label_overlap=0.25,classes=['GWWA_song'])\n",
+    "# Split the annotations using the returned clip_df\n",
+    "labels_df = annotations.one_hot_labels_like(\n",
+    "    clip_df,\n",
+    "    min_label_overlap=0.25, # Minimum label overlap\n",
+    "    classes=['GWWA_song']\n",
+    ")\n",
     "\n",
     "#the returned dataframe of one-hot labels (0/1 for each class and each clip) has rows corresponding to each audio clip\n",
     "labels_df.head()"
@@ -934,16 +1139,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3. Split annotations directly using splitting parameters\n",
+    "### 2. Split annotations directly using splitting parameters\n",
     "\n",
-    "Though we recommend using one of the above methods, you can also split annotations by directly calling `one_hot_clip_labels()`. This method combines the two steps in the examples above (creating a clip df and splitting the annotations), and requires that you specify the parameters for both of those steps. \n",
+    "If you prefer to split only annotations, you can do this using `one_hot_clip_labels()`. \n",
     "\n",
-    "Here's an example that produces equivalent results to the previous examples:"
+    "This method combines the two steps in the example above (creating a clip dataframe and splitting the annotations), and requires that you specify the parameters for both of those steps. \n",
+    "\n",
+    "Notice that we can't tell what the length of the entire audio file is from the annotation file alone, so we need to specify one additional parameter: the entire duration of the audio file to be split (`full_duration`).\n",
+    "\n",
+    "Here's an example that produces equivalent results to the other examples:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -1016,18 +1225,18 @@
        "20         25              1.0"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "labels_df = annotations.one_hot_clip_labels(\n",
-    "    full_duration=60,\n",
-    "    clip_duration=5,\n",
-    "    clip_overlap=0,\n",
+    "    full_duration=60, # The duration of the entire audio file\n",
+    "    clip_duration=5, \n",
+    "    clip_overlap=0, # By how many seconds subsequent files should overlap\n",
     "    classes=['GWWA_song'],\n",
-    "    min_label_overlap=0.25,    \n",
+    "    min_label_overlap=0.25, # The number of seconds of overlap a label should have over a clip\n",
     ")\n",
     "labels_df.head()"
    ]
@@ -1036,26 +1245,222 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Create audio clips and one-hot labels from many audio and annotation files\n",
+    "### 3. Split annotations using your own clip DF\n",
     "\n",
-    "Let's get to the useful part - you have tons of audio files (with corresponding Raven files) and you need to create one-hot labels for 5 second clips on all of them. Can't we just give you the code you need to get this done?! \n",
+    "A more verbose option than #2: we can split annotations using a separately created DataFrame of start and end times.\n",
     "\n",
-    "Sure :)\n",
+    "This method could be useful if you wished to hand-create the DataFrame of clip start and end times to have more control over the start and end times you were interested in.\n",
     "\n",
-    "but be warned, matching up the correct raven and audio files might require some finagling"
+    "In this example, we will use a helper function to create the DataFrame, `generate_clip_times_df()`, which takes the same splitting parameters as `Audio.split()`. \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>start_time</th>\n",
+       "      <th>end_time</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>5.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>5.0</td>\n",
+       "      <td>10.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>10.0</td>\n",
+       "      <td>15.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>15.0</td>\n",
+       "      <td>20.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>20.0</td>\n",
+       "      <td>25.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   start_time  end_time\n",
+       "0         0.0       5.0\n",
+       "1         5.0      10.0\n",
+       "2        10.0      15.0\n",
+       "3        15.0      20.0\n",
+       "4        20.0      25.0"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Generate clip start/end time DataFrame\n",
+    "from opensoundscape.helpers import generate_clip_times_df\n",
+    "clip_df = generate_clip_times_df(full_duration=60, clip_duration=5.0, clip_overlap=0.0)\n",
+    "clip_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>GWWA_song</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>start_time</th>\n",
+       "      <th>end_time</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0.0</th>\n",
+       "      <th>5.0</th>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5.0</th>\n",
+       "      <th>10.0</th>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10.0</th>\n",
+       "      <th>15.0</th>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15.0</th>\n",
+       "      <th>20.0</th>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20.0</th>\n",
+       "      <th>25.0</th>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                     GWWA_song\n",
+       "start_time end_time           \n",
+       "0.0        5.0             1.0\n",
+       "5.0        10.0            1.0\n",
+       "10.0       15.0            0.0\n",
+       "15.0       20.0            0.0\n",
+       "20.0       25.0            1.0"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# We can use the clip_df to split the Annotations in the same way as before\n",
+    "labels_df = annotations.one_hot_labels_like(clip_df, min_label_overlap=0.25, classes=['GWWA_song'])\n",
+    "\n",
+    "# The returned dataframe of one-hot labels (0/1 for each class and each clip) has rows corresponding to each audio clip\n",
+    "labels_df.head()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### find all the Raven and audio files, and see if they match up one-to-one\n",
-    "caveat: you'll need to be careful about matching up the correct Raven files and audio files. In this example, we'll assume our Raven files have exactly the same name (ignoring the extensions like \".Table.1.selections.txt\") as our audio files, *and* that these file names *are unique (!)* - that is, no two audio files have the same name. "
+    "## Split many audio clips and their annotations\n",
+    "\n",
+    "The steps above described how to split a single audio clip and its annotations.\n",
+    "\n",
+    "In practice, we have tons of audio files with their corresponding Raven files. We need to:\n",
+    "\n",
+    "* Pair up all the audio files with their Raven annotation files\n",
+    "\n",
+    "* Split and save short audio clips\n",
+    "\n",
+    "* Split and save the annotations corresponding to the audio clips\n",
+    "\n",
+    "Let's walk through the steps required to do this. But be warned, pairing Raven files and audio files might require more finagling than shown here."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Match up audio files and Raven annotations\n",
+    "\n",
+    "The first step in the process is associating audio files with their corresponding Raven files. Perhaps not every audio file is annotated, and perhaps some audio files have been annotated multiple times. This code walks through some steps of sorting through these data to pair files.\n",
+    "\n",
+    "**Caveat: you'll need to be careful** using the code below, depending on how your audio and Raven files are named and organized.\n",
+    "\n",
+    "In this example, we'll assume that each audio file has the same name as its Raven annotation file (ignoring the extensions like \".Table.1.selections.txt\"), which is the default naming convention when using Raven. We'll also start by assuming that the audio filenames *are unique (!)* - that is, no two audio files have the same name. \n",
+    "\n",
+    "First, find all the Raven files and all the audio files."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -1063,7 +1468,44 @@
      "output_type": "stream",
      "text": [
       "found 3 annotation files\n",
-      "found 3 audio files\n",
+      "found 3 audio files\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Specify folder containing Raven annotations\n",
+    "raven_files_dir = \"./gwwa_audio_and_raven_annotations/GWWA_XC_AnnoTables/\"\n",
+    "\n",
+    "# Find all .txt files\n",
+    "# We'll naively assume all files with the suffix \".txt\" are Raven files! \n",
+    "# A better assumption could be to search for files with the suffix \".selections.txt\"\n",
+    "raven_files = glob(f\"{raven_files_dir}/*.txt\")\n",
+    "print(f\"found {len(raven_files)} annotation files\")\n",
+    "\n",
+    "# Specify folder containing audio files\n",
+    "audio_files_dir = \"./gwwa_audio_and_raven_annotations/GWWA_XC/\"\n",
+    "\n",
+    "# Find all audio files (we'll assume they are .wav, .WAV, or .mp3)\n",
+    "audio_files = glob(f\"{audio_files_dir}/*.wav\")+glob(f\"{audio_files_dir}/*.WAV\")+glob(f\"{audio_files_dir}/*.mp3\")\n",
+    "print(f\"found {len(audio_files)} audio files\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, starting by assuming that audio files have unique names, use the audio filenames to pair up the annotation files. Then, double-check that our assumption is correct."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
       " audio files with duplicate names:\n"
      ]
@@ -1103,39 +1545,32 @@
        "Index: []"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# specify folder containing Raven annotations\n",
-    "raven_files_dir = \"./gwwa_audio_and_raven_annotations/GWWA_XC_AnnoTables/\"\n",
-    "\n",
-    "# find all .txt files (we'll naively assume all txt files are Raven files!)\n",
-    "raven_files = glob(f\"{raven_files_dir}/*.txt\")\n",
-    "print(f\"found {len(raven_files)} annotation files\")\n",
-    "\n",
-    "#specify folder containing audio files\n",
-    "audio_files_dir = \"./gwwa_audio_and_raven_annotations/GWWA_XC/\"\n",
-    "\n",
-    "# find all audio files (we'll assume they are .wav, .WAV, or .mp3)\n",
-    "audio_files = glob(f\"{audio_files_dir}/*.wav\")+glob(f\"{audio_files_dir}/*.WAV\")+glob(f\"{audio_files_dir}/*.mp3\")\n",
-    "print(f\"found {len(audio_files)} audio files\")\n",
-    "\n",
-    "# pair up the raven and audio files based on the audio file name\n",
+    "# Pair up the Raven and audio files based on the audio file name\n",
     "from pathlib import Path\n",
     "audio_df = pd.DataFrame({'audio_file':audio_files})\n",
     "audio_df.index = [Path(f).stem for f in audio_files]\n",
     "\n",
-    "#check that there aren't duplicate audio file names\n",
+    "# Check that there aren't duplicate audio file names\n",
     "print('\\n audio files with duplicate names:')\n",
     "audio_df[audio_df.index.duplicated(keep=False)]"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Seeing that no audio files have duplicate names, check to make sure the same is true for Raven files."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -1189,7 +1624,7 @@
        "13738  ./gwwa_audio_and_raven_annotations/GWWA_XC_Ann..."
       ]
      },
-     "execution_count": 16,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1207,12 +1642,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once we've resolved any issues with duplicate names, we can match up raven and audio files."
+    "Since we found some duplicate Raven files, resolve this issue by deleting the extra Raven file, which in this case was named \"selections2\"."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1221,8 +1656,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once we've resolved any issues with duplicate names, we can match up Raven and audio files."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1233,12 +1675,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "check if any audio files don't have annotation files"
+    "Check if any audio files don't have Raven annotation files:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -1294,7 +1736,7 @@
        "13742   ./gwwa_audio_and_raven_annotations/GWWA_XC/137...        NaN"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1308,12 +1750,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "check if any raven files don't have audio files"
+    "Check if any Raven files don't have audio files:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -1363,7 +1805,7 @@
        "16989        NaN  ./gwwa_audio_and_raven_annotations/GWWA_XC_Ann..."
       ]
      },
-     "execution_count": 20,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1379,12 +1821,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example, let's discard any unpaired raven or audio files"
+    "In this example, let's discard any unpaired Raven or audio files."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1393,7 +1835,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -1439,7 +1881,7 @@
        "13738  ./gwwa_audio_and_raven_annotations/GWWA_XC_Ann...  "
       ]
      },
-     "execution_count": 22,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1452,93 +1894,85 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### split and save the audio and annotations\n",
-    "Now we have a set of paired up raven and audio files. \n",
+    "### Split and save the audio and annotations\n",
+    "Now we have a set of paired up Raven and audio files. \n",
     "\n",
-    "Let's split each of the audio files and create the corresponding labels. \n",
+    "Let's split each of the audio files and create the corresponding labels.\n",
     "\n",
-    "We'll want to keep the names of the audio clips that we create using Audio.split_and_save() so that we can correspond them with one-hot clip labels.\n",
+    "Note: this step will be confusing and annoying if your Raven files use different names for the annotation column. Ideally, all of your Raven files should have the same column name for the annotations. \n",
     "\n",
-    "Note: it will be confusing and annoying if your Raven files use different names for the annotation column. Ideally, all of your raven files should have the same column name for the annotations. "
+    "First, make a directory to put the split audio files in."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash \n",
-    "mkdir -p ./temp_clips"
+    "clip_dir = './temp_clips'\n",
+    "Path(clip_dir).mkdir(exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, set up the settings for audio splitting:\n",
+    "* The duration of the clips\n",
+    "\n",
+    "* Whether subsequent clips should overlap each other (e.g., `clip_overlap=1` would mean that the second clip started 1s before the first clip ended)\n",
+    "\n",
+    "* What to do with the final clip if it would be less than `clip_duration` size (see API documentation for full information about the options for this)\n",
+    "\n",
+    "* And the directory in which to save audio files."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#choose settings for audio splitting\n",
+    "# Choose settings for audio splitting\n",
     "clip_duration = 3\n",
     "clip_overlap = 0\n",
     "final_clip = None\n",
-    "clip_dir = './temp_clips'\n",
+    "clip_dir = './temp_clips'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, set up the settings for annotation splitting:\n",
     "\n",
-    "#choose settings for annotation splitting\n",
-    "classes = None#['GWWA_song','GWWA_dzit'] #list of all classes, or None\n",
-    "min_label_overlap = 0.1\n",
+    "* Whether to use a subset of classes\n",
     "\n",
-    "\n",
-    "#store the label dataframes from each audio file so that we can aggregate them later\n",
-    "#Note: if you have a huge number (millions) of annotations, this might get very large. \n",
-    "#an alternative would be to save the individual dataframes to files, then concatenate them later. \n",
-    "all_labels = []\n",
-    "\n",
-    "cnt = 0\n",
-    "\n",
-    "for i, row in paired_df.iterrows():\n",
-    "    #load the audio into an Audio object\n",
-    "    audio = Audio.from_file(row['audio_file'])\n",
-    "    \n",
-    "    #in this example, only the first 60 seconds of audio is annotated\n",
-    "    #so trim the audio to 60 seconds max\n",
-    "    audio = audio.trim(0,60)\n",
-    "    \n",
-    "    #split the audio and save the clips\n",
-    "    clip_df = audio.split_and_save(\n",
-    "        clip_dir,\n",
-    "        prefix=row.name,\n",
-    "        clip_duration=clip_duration,\n",
-    "        clip_overlap=clip_overlap,\n",
-    "        final_clip=final_clip,\n",
-    "        dry_run=False\n",
-    "    )\n",
-    "    \n",
-    "    #load the annotation file into a BoxedAnnotation object\n",
-    "    annotations = BoxedAnnotations.from_raven_file(row['raven_file'],annotation_column='Species')\n",
-    "    \n",
-    "    #since we trimmed the audio, we'll also trim the annotations for consistency\n",
-    "    annotations = annotations.trim(0,60)\n",
-    "    \n",
-    "    #split the annotations to match the audio\n",
-    "    #we choose to keep_index=True so that we retain the audio clip's path in the final label dataframe\n",
-    "    labels = annotations.one_hot_labels_like(clip_df,classes=classes,min_label_overlap=min_label_overlap,keep_index=True)\n",
-    "    \n",
-    "    #since we have saved short audio clips, we can discard the start_time and end_time indices\n",
-    "    labels = labels.reset_index(level=[1,2],drop=True)\n",
-    "    all_labels.append(labels)\n",
-    "    \n",
-    "    cnt+=1\n",
-    "    if cnt>2:\n",
-    "        break\n",
-    "\n",
-    "#make one big dataframe with all of the labels. We could use this for training, for instance. \n",
-    "all_labels = pd.concat(all_labels)"
+    "* How many seconds a label should overlap a clip, at minimum, in order for that clip to be labeled"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Choose settings for annotation splitting\n",
+    "classes = None #Equivalent to a list of all classes: ['GWWA_song', '?']\n",
+    "min_label_overlap = 0.1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll want to keep the names of the audio clips that we create using `Audio.split_and_save()` so that we can correspond them with one-hot clip labels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -1689,12 +2123,58 @@
        "./temp_clips/13738_51.0s_54.0s.wav  0.0        1.0"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "# Store the label dataframes from each audio file so that we can aggregate them later\n",
+    "# Note: if you have a huge number (millions) of annotations, this might get very large. \n",
+    "# An alternative would be to save the individual dataframes to files, then concatenate them later. \n",
+    "all_labels = []\n",
+    "\n",
+    "cnt = 0\n",
+    "\n",
+    "for i, row in paired_df.iterrows():\n",
+    "    # Load the audio into an Audio object\n",
+    "    audio = Audio.from_file(row['audio_file'])\n",
+    "    \n",
+    "    # In this example, only the first 60 seconds of audio is annotated\n",
+    "    # So trim the audio to 60 seconds max\n",
+    "    audio = audio.trim(0,60)\n",
+    "    \n",
+    "    # Split the audio and save the clips\n",
+    "    clip_df = audio.split_and_save(\n",
+    "        clip_dir,\n",
+    "        prefix=row.name,\n",
+    "        clip_duration=clip_duration,\n",
+    "        clip_overlap=clip_overlap,\n",
+    "        final_clip=final_clip,\n",
+    "        dry_run=False\n",
+    "    )\n",
+    "    \n",
+    "    # Load the annotation file into a BoxedAnnotation object\n",
+    "    annotations = BoxedAnnotations.from_raven_file(row['raven_file'],annotation_column='Species')\n",
+    "    \n",
+    "    # Since we trimmed the audio, we'll also trim the annotations for consistency\n",
+    "    annotations = annotations.trim(0,60)\n",
+    "    \n",
+    "    # Split the annotations to match the audio\n",
+    "    # We choose to keep_index=True so that we retain the audio clip's path in the final label dataframe\n",
+    "    labels_df = annotations.one_hot_labels_like(clip_df,classes=classes,min_label_overlap=min_label_overlap,keep_index=True)\n",
+    "    \n",
+    "    # Since we have saved short audio clips, we can discard the start_time and end_time indices\n",
+    "    labels_df = labels_df.reset_index(level=[1,2],drop=True)\n",
+    "    all_labels.append(labels_df)\n",
+    "    \n",
+    "    cnt+=1\n",
+    "    if cnt>2:\n",
+    "        break\n",
+    "\n",
+    "#make one big dataframe with all of the labels. We could use this for training, for instance. \n",
+    "all_labels = pd.concat(all_labels)\n",
+    "all_labels.to_csv(\"temp_clips/clip_annotations.csv\")\n",
     "all_labels"
    ]
   },
@@ -1702,12 +2182,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### sanity check: look at spectrograms of clips labeled 0 and 1"
+    "### Sanity check: look at spectrograms of clips labeled 0 and 1"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1716,9 +2196,18 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 27,
+   "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "Note: replace the \"GWWA_song\" here with a class name from your own dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1849,12 +2338,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "clean up: remove temp_clips directory"
+    "Clean up: remove the sounds that we downloaded for this tutorial as well as the `temp_clips` directory containing the split, saved clips."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1866,9 +2355,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "opso_dev",
+   "display_name": "opso-dev",
    "language": "python",
-   "name": "opso_dev"
+   "name": "opso-dev"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/tutorials/annotation_tutorial.ipynb
+++ b/docs/tutorials/annotation_tutorial.ipynb
@@ -1234,9 +1234,9 @@
     "labels_df = annotations.one_hot_clip_labels(\n",
     "    full_duration=60, # The duration of the entire audio file\n",
     "    clip_duration=5, \n",
-    "    clip_overlap=0, # By how many seconds subsequent files should overlap\n",
+    "    clip_overlap=0,\n",
     "    classes=['GWWA_song'],\n",
-    "    min_label_overlap=0.25, # The number of seconds of overlap a label should have over a clip\n",
+    "    min_label_overlap=0.25,\n",
     ")\n",
     "labels_df.head()"
    ]


### PR DESCRIPTION
This pull request makes some minor changes to the annotation Jupyter Notebook tutorial for the documentation.

It revises the section about splitting a single audio clip and its annotations to add more introductory detail, including an explanation of what "one-hot encoding" is, identifying which of the three examples splits audio, and adding more detail about the parameter arguments for some of the audio/splitting functions.

It also fixes typos & makes minor stylistic changes throughout the notebook.