### PR TITLE
Fixes Poetry Installer issue during CI

### DIFF
--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install ffmpeg v4
         run: sudo snap install ffmpeg
       - name: Install poetry
-        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+        run: curl -sSL https://install.python-poetry.org | python
       - name: Poetry install
         run: ~/.poetry/bin/poetry install
       - name: Poetry run pytest


### PR DESCRIPTION
Continuous Integration was failing at the poetry install stage. See e.g. https://github.com/kitzeslab/opensoundscape/runs/8274770498 

I think this is because we have to change how poetry is installed during CI. To do this, I have edited the `/.github/workflows/poetry.yaml` file to update the poetry installation script. 
see https://github.com/python-poetry/poetry/issues/6377