### PR TITLE
Resolve Issue 507 metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ doc/_build/
 *.ipynb_checkpoints/
 *.DS_Store
 docs/tutorials/woodcock_labeled_data
+.vscode

--- a/opensoundscape/metrics.py
+++ b/opensoundscape/metrics.py
@@ -86,11 +86,11 @@ def multi_target_metrics(targets, scores, class_names, threshold):
     except ValueError:
         metrics_dict["hamming_loss"] = np.nan
     try:
-        metrics_dict["map"] = average_precision_score(targets, preds, average="macro")
+        metrics_dict["map"] = average_precision_score(targets, scores, average="macro")
     except ValueError:
         metrics_dict["map"] = np.nan
     try:
-        metrics_dict["au_roc"] = roc_auc_score(targets, preds, average="macro")
+        metrics_dict["au_roc"] = roc_auc_score(targets, scores, average="macro")
     except ValueError:
         metrics_dict["au_roc"] = np.nan
 
@@ -143,11 +143,11 @@ def single_target_metrics(targets, scores, class_names):
     except ValueError:
         metrics_dict["hamming_loss"] = np.nan
     try:
-        metrics_dict["map"] = average_precision_score(targets, preds, average="macro")
+        metrics_dict["map"] = average_precision_score(targets, scores, average="macro")
     except ValueError:
         metrics_dict["map"] = np.nan
     try:
-        metrics_dict["au_roc"] = roc_auc_score(targets, preds, average="macro")
+        metrics_dict["au_roc"] = roc_auc_score(targets, scores, average="macro")
     except ValueError:
         metrics_dict["au_roc"] = np.nan
 

--- a/opensoundscape/metrics.py
+++ b/opensoundscape/metrics.py
@@ -142,13 +142,5 @@ def single_target_metrics(targets, scores, class_names):
         metrics_dict["hamming_loss"] = hamming_loss(targets, preds)
     except ValueError:
         metrics_dict["hamming_loss"] = np.nan
-    try:
-        metrics_dict["map"] = average_precision_score(targets, scores, average="macro")
-    except ValueError:
-        metrics_dict["map"] = np.nan
-    try:
-        metrics_dict["au_roc"] = roc_auc_score(targets, scores, average="macro")
-    except ValueError:
-        metrics_dict["au_roc"] = np.nan
 
     return metrics_dict

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -7,11 +7,14 @@ from opensoundscape import metrics
 # metrics are currently implicitly tested through test_cnn
 # however, we should add explicit tests
 def test_multitarget_metrics():
-    x = [[0, 1], [1, 0]]
-    y = [[0, 1], [1, 1]]
+    x = [[0, 1], [0.4,1],[0.6,1],[1,0]]
+    y = [[0, 1], [1, 0],[0,1],[1,0]]
     out = metrics.multi_target_metrics(y, x, [0, 1], 0.5)
-    assert out["precision"] == 1
-    assert out["recall"] == 0.75
+    assert np.isclose(out["precision"],0.58333333,1e-5)
+    assert np.isclose(out["recall"],0.75,1e-5)
+    assert np.isclose(out["map"],0.75,1e-5)
+    assert np.isclose(out["au_roc"],0.75,1e-5)
+
 
 
 def test_singletarget_metrics():

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -7,14 +7,13 @@ from opensoundscape import metrics
 # metrics are currently implicitly tested through test_cnn
 # however, we should add explicit tests
 def test_multitarget_metrics():
-    x = [[0, 1], [0.4,1],[0.6,1],[1,0]]
-    y = [[0, 1], [1, 0],[0,1],[1,0]]
+    x = [[0, 1], [0.4, 1], [0.6, 1], [1, 0]]
+    y = [[0, 1], [1, 0], [0, 1], [1, 0]]
     out = metrics.multi_target_metrics(y, x, [0, 1], 0.5)
-    assert np.isclose(out["precision"],0.58333333,1e-5)
-    assert np.isclose(out["recall"],0.75,1e-5)
-    assert np.isclose(out["map"],0.75,1e-5)
-    assert np.isclose(out["au_roc"],0.75,1e-5)
-
+    assert np.isclose(out["precision"], 0.58333333, 1e-5)
+    assert np.isclose(out["recall"], 0.75, 1e-5)
+    assert np.isclose(out["map"], 0.75, 1e-5)
+    assert np.isclose(out["au_roc"], 0.75, 1e-5)
 
 
 def test_singletarget_metrics():


### PR DESCRIPTION
This branch fixes incorrect calculation of MAP and AU_ROC scores in the `metrics` module. Specifically, these metrics should take continuous 0-1 scores as input rather than [0,1] predictions. I've added a couple of tests to make sure the results of the MAP and AU_ROC scores are what I would expect, but a reviewer double-checking that the behavior is correct would be helpful. 