### PR TITLE
resolve 513 Spectrogram loses properties on out-of-place method

### DIFF
--- a/opensoundscape/spectrogram.py
+++ b/opensoundscape/spectrogram.py
@@ -334,6 +334,11 @@ class Spectrogram:
             self.frequencies,
             self.times,
             self.decibel_limits,
+            self.window_samples,
+            self.overlap_samples,
+            self.window_type,
+            self.audio_sample_rate,
+            self.scaling,
         )
 
     def limit_db_range(self, min_db=-100, max_db=-20):
@@ -360,7 +365,17 @@ class Spectrogram:
         _spec[_spec > max_db] = max_db
         _spec[_spec < min_db] = min_db
 
-        return self.__class__(_spec, self.frequencies, self.times, self.decibel_limits)
+        return self.__class__(
+            _spec,
+            self.frequencies,
+            self.times,
+            self.decibel_limits,
+            self.window_samples,
+            self.overlap_samples,
+            self.window_type,
+            self.audio_sample_rate,
+            self.scaling,
+        )
 
     def bandpass(self, min_f, max_f, out_of_bounds_ok=True):
         """extract a frequency band from a spectrogram
@@ -402,6 +417,11 @@ class Spectrogram:
             self.frequencies[lowest_index : highest_index + 1],
             self.times,
             self.decibel_limits,
+            self.window_samples,
+            self.overlap_samples,
+            self.window_type,
+            self.audio_sample_rate,
+            self.scaling,
         )
 
     def trim(self, start_time, end_time):
@@ -426,6 +446,11 @@ class Spectrogram:
             self.frequencies,
             self.times[lowest_index : highest_index + 1],
             self.decibel_limits,
+            self.window_samples,
+            self.overlap_samples,
+            self.window_type,
+            self.audio_sample_rate,
+            self.scaling,
         )
 
     def plot(self, inline=True, fname=None, show_colorbar=False):

--- a/tests/test_spectrogram.py
+++ b/tests/test_spectrogram.py
@@ -10,6 +10,20 @@ from math import isclose
 def veryshort_wav_str():
     return "tests/audio/veryshort.wav"
 
+@pytest.fixture()
+def spec():
+    return Spectrogram(
+        np.zeros((5, 10)),
+        np.linspace(0, 100, 5), 
+        np.linspace(0, 10, 10), 
+        decibel_limits=(-100, -20),
+        window_samples=100,
+        overlap_samples=50,
+        window_type='Hann',
+        audio_sample_rate=44100,
+        scaling='spectrum'
+    )
+
 
 def test_spectrogram_raises_typeerror():
     with pytest.raises(TypeError):
@@ -94,10 +108,16 @@ def test_construct_spectrogram():
     Spectrogram(np.zeros((5, 10)), np.zeros((5)), np.zeros((10)), (-100, -20))
 
 
-def test_bandpass_spectrogram():
-    Spectrogram(
-        np.zeros((5, 10)), np.linspace(0, 100, 5), np.linspace(0, 10, 10), (-100, -20)
-    ).bandpass(2, 4)
+def test_bandpass_spectrogram(spec):
+    spec = spec.bandpass(25,75)
+    assert np.allclose(spec.frequencies,np.array([25,50,75]))
+    #make sure it didn't loose any properties
+    assert spec.decibel_limits==(-100, -20)
+    assert spec.window_samples==100
+    assert spec.overlap_samples==50
+    assert spec.window_type=='Hann'
+    assert spec.audio_sample_rate==44100
+    assert spec.scaling=='spectrum'
 
 
 def test_bandpass_spectrogram_out_of_bounds():
@@ -126,10 +146,15 @@ def test_bandpass_spectrogram_bad_limits():
         ).bandpass(4, 2)
 
 
-def test_trim_spectrogram():
-    Spectrogram(
-        np.zeros((5, 10)), np.linspace(0, 100, 5), np.linspace(0, 10, 10), (-100, -20)
-    ).trim(2, 4)
+def test_trim_spectrogram(spec):
+    spec = spec.trim(2, 4)
+    #make sure it didn't loose any properties
+    assert spec.decibel_limits==(-100, -20)
+    assert spec.window_samples==100
+    assert spec.overlap_samples==50
+    assert spec.window_type=='Hann'
+    assert spec.audio_sample_rate==44100
+    assert spec.scaling=='spectrum'
 
 
 def test_limit_db_range():

--- a/tests/test_spectrogram.py
+++ b/tests/test_spectrogram.py
@@ -10,18 +10,19 @@ from math import isclose
 def veryshort_wav_str():
     return "tests/audio/veryshort.wav"
 
+
 @pytest.fixture()
 def spec():
     return Spectrogram(
         np.zeros((5, 10)),
-        np.linspace(0, 100, 5), 
-        np.linspace(0, 10, 10), 
+        np.linspace(0, 100, 5),
+        np.linspace(0, 10, 10),
         decibel_limits=(-100, -20),
         window_samples=100,
         overlap_samples=50,
-        window_type='Hann',
+        window_type="Hann",
         audio_sample_rate=44100,
-        scaling='spectrum'
+        scaling="spectrum",
     )
 
 
@@ -109,15 +110,15 @@ def test_construct_spectrogram():
 
 
 def test_bandpass_spectrogram(spec):
-    spec = spec.bandpass(25,75)
-    assert np.allclose(spec.frequencies,np.array([25,50,75]))
-    #make sure it didn't loose any properties
-    assert spec.decibel_limits==(-100, -20)
-    assert spec.window_samples==100
-    assert spec.overlap_samples==50
-    assert spec.window_type=='Hann'
-    assert spec.audio_sample_rate==44100
-    assert spec.scaling=='spectrum'
+    spec = spec.bandpass(25, 75)
+    assert np.allclose(spec.frequencies, np.array([25, 50, 75]))
+    # make sure it didn't loose any properties
+    assert spec.decibel_limits == (-100, -20)
+    assert spec.window_samples == 100
+    assert spec.overlap_samples == 50
+    assert spec.window_type == "Hann"
+    assert spec.audio_sample_rate == 44100
+    assert spec.scaling == "spectrum"
 
 
 def test_bandpass_spectrogram_out_of_bounds():
@@ -148,13 +149,13 @@ def test_bandpass_spectrogram_bad_limits():
 
 def test_trim_spectrogram(spec):
     spec = spec.trim(2, 4)
-    #make sure it didn't loose any properties
-    assert spec.decibel_limits==(-100, -20)
-    assert spec.window_samples==100
-    assert spec.overlap_samples==50
-    assert spec.window_type=='Hann'
-    assert spec.audio_sample_rate==44100
-    assert spec.scaling=='spectrum'
+    # make sure it didn't loose any properties
+    assert spec.decibel_limits == (-100, -20)
+    assert spec.window_samples == 100
+    assert spec.overlap_samples == 50
+    assert spec.window_type == "Hann"
+    assert spec.audio_sample_rate == 44100
+    assert spec.scaling == "spectrum"
 
 
 def test_limit_db_range():


### PR DESCRIPTION
Resolves #513 , a bug where applying Spectrogram out-of-place methods such as .trim() and .bandpass() would return a Spectrogram without all of the properties retained. Adds tests to ensure properties are retained. 