### PR TITLE
Fix loading of ResampleLoss CNN models

### DIFF
--- a/opensoundscape/torch/models/cnn.py
+++ b/opensoundscape/torch/models/cnn.py
@@ -1054,6 +1054,12 @@ def load_model(path, device=None):
             torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")
         )
     model = torch.load(path, map_location=device)
+
+    # since ResampleLoss class overrides a method of an instance,
+    # we need to re-change the _init_loss_fn change when we reload
+    if model.loss_cls == ResampleLoss:
+        use_resample_loss(model)
+
     model.device = device
     return model
 


### PR DESCRIPTION
Fixes #509 - an issue where CNN objects that had use_resample_loss() applied failed to train after being loaded with load_model().

The patch is a bit hacky, I'm not sure I understand why the re-loaded object doesn't have the changes applied by use_resample_loss (that function modifies an instance method rather than the class, so it makes sense that a new instance doesn't have the modified function. But this raises the question of how to save a model object if you've manipulated instance methods/variables, or whether we should avoid modifying instance methods.) The solution in this patch is simply to re-apply use_resample_loss() to the loaded object if the object's .loss_cls attribute is ResampleLoss. 

This PR also cleans up test_cnn a bit