### PR TITLE
different # input channels should retain pre-trained weights 

### DIFF
--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -60,6 +60,12 @@ Data Selection
 .. automodule:: opensoundscape.data_selection
   :members:
 
+Datasets
+^^^^^^^^
+
+.. automodule:: opensoundscape.torch.datasets
+  :members:
+
 
 Grad Cam
 ^^^^^^^^

--- a/docs/tutorials/predict_with_pretrained_cnn.ipynb
+++ b/docs/tutorials/predict_with_pretrained_cnn.ipynb
@@ -1024,7 +1024,6 @@
     "dict_to_save = {\n",
     "    'network_state_dict':model.network.state_dict(),\n",
     "    'classes': model.classes,\n",
-    "    '\n",
     "}\n",
     "torch.save(dict_to_save, '/path/to/model_dict.pt')\n",
     "\n",

--- a/opensoundscape/preprocess/actions.py
+++ b/opensoundscape/preprocess/actions.py
@@ -33,7 +33,7 @@ class BaseAction:
     """
 
     def __init__(self):
-        self.params = pd.Series(dtype=object)
+        self.params = pd.Series(dtype="object")
         self.extra_args = []
         self.returns_labels = False
         self.is_augmentation = False
@@ -55,7 +55,7 @@ class BaseAction:
         assert unmatched_args == set(
             []
         ), f"unexpected arguments: {unmatched_args}. The valid arguments and current values are: \n{self.params}"
-        self.params.update(kwargs)
+        self.params.update(pd.Series(kwargs, dtype=object))
 
     def get(self, arg):
         return self.params[arg]

--- a/opensoundscape/torch/architectures/cnn_architectures.py
+++ b/opensoundscape/torch/architectures/cnn_architectures.py
@@ -28,6 +28,8 @@ or override an existing model's architecture:
 Note: the InceptionV3 architecture must be used differently than other
 architectures - the easiest way is to simply use the InceptionV3 class in
 opensoundscape.torch.models.cnn.
+
+Note 2: For resnet architectures, if num_channels != 3, averages the conv1 weights across all channels.
 """
 from torchvision import models
 from torch import nn
@@ -55,7 +57,10 @@ def freeze_params(model):
 
 
 def modify_resnet(model, num_classes, num_channels):
-    """modify input and output shape of a resnet architecture"""
+    """modify input and output shape of a resnet architecture
+
+    If num_channels != 3, averages the conv1 weights across all channels.
+    """
     num_ftrs = model.fc.in_features
     model.fc = nn.Linear(num_ftrs, num_classes)
     if num_channels != 3:
@@ -90,7 +95,7 @@ def resnet18(
             if True, feature block is frozen and only final layer is trained
         use_pretrained:
             if True, uses pre-trained ImageNet features from
-            Pytorch's model zoo.
+            Pytorch's model zoo. If num_channels != 3, averages the conv1 weights across all channels.
         num_channels:
             specify channels in input sample, eg [channels h,w] sample shape
     """
@@ -117,7 +122,7 @@ def resnet34(
             if True, feature block is frozen and only final layer is trained
         use_pretrained:
             if True, uses pre-trained ImageNet features from
-            Pytorch's model zoo.
+            Pytorch's model zoo. If num_channels != 3, averages the conv1 weights across all channels.
         num_channels:
             specify channels in input sample, eg [channels h,w] sample shape
     """
@@ -144,7 +149,7 @@ def resnet50(
             if True, feature block is frozen and only final layer is trained
         use_pretrained:
             if True, uses pre-trained ImageNet features from
-            Pytorch's model zoo.
+            Pytorch's model zoo. If num_channels != 3, averages the conv1 weights across all channels.
         num_channels:
             specify channels in input sample, eg [channels h,w] sample shape
     """
@@ -171,7 +176,7 @@ def resnet101(
             if True, feature block is frozen and only final layer is trained
         use_pretrained:
             if True, uses pre-trained ImageNet features from
-            Pytorch's model zoo.
+            Pytorch's model zoo. If num_channels != 3, averages the conv1 weights across all channels.
         num_channels:
             specify channels in input sample, eg [channels h,w] sample shape
     """
@@ -198,7 +203,7 @@ def resnet152(
             if True, feature block is frozen and only final layer is trained
         use_pretrained:
             if True, uses pre-trained ImageNet features from
-            Pytorch's model zoo.
+            Pytorch's model zoo. If num_channels != 3, averages the conv1 weights across all channels.
         num_channels:
             specify channels in input sample, eg [channels h,w] sample shape
     """

--- a/opensoundscape/torch/architectures/cnn_architectures.py
+++ b/opensoundscape/torch/architectures/cnn_architectures.py
@@ -32,6 +32,7 @@ opensoundscape.torch.models.cnn.
 from torchvision import models
 from torch import nn
 from opensoundscape.torch.architectures.utils import CompositeArchitecture
+import torch
 
 ARCH_DICT = dict()
 
@@ -59,9 +60,17 @@ def modify_resnet(model, num_classes, num_channels):
     model.fc = nn.Linear(num_ftrs, num_classes)
     if num_channels != 3:
         # modify the input layer to accept custom # channels other than 3
+        # first make a copy of the weights from original model
+        avg_conv1_weights = torch.repeat_interleave(
+            torch.unsqueeze(torch.mean(model.conv1.weight, 1), 1), num_channels, 1
+        )
+        # change the shape of the first convolution to accept n channels
         model.conv1 = nn.Conv2d(
             num_channels, 64, kernel_size=7, stride=2, padding=3, bias=False
         )
+        # reapply the average weights of the original architecture's conv1
+        model.conv1.weight = torch.nn.Parameter(avg_conv1_weights)
+
     return model
 
 

--- a/opensoundscape/torch/models/cnn.py
+++ b/opensoundscape/torch/models/cnn.py
@@ -49,12 +49,15 @@ class CNN(BaseModule):
             cnn_architectures.list_architectures(), eg 'resnet18'.
             - If a string is provided, uses default parameters
                 (including use_pretrained=True)
+                Note: For resnet architectures, if num_channels != 3,
+                averages the conv1 weights across all channels.
         classes:
             list of class names. Must match with training dataset classes if training.
         single_target:
             - True: model expects exactly one positive class per sample
             - False: samples can have any number of positive classes
             [default: False]
+
     """
 
     def __init__(

--- a/opensoundscape/torch/models/cnn.py
+++ b/opensoundscape/torch/models/cnn.py
@@ -398,8 +398,7 @@ class CNN(BaseModule):
                 Note: the best model is always saved to best.model
                 in addition to other saved epochs.
             log_interval:
-                interval in epochs to evaluate model with validation
-                dataset and print metrics to the log
+                interval in batches to print training loss/metrics
             validation_interval:
                 interval in epochs to test the model on the validation set
                 Note that model will only update it's best score and save best.model


### PR DESCRIPTION
resolves #508 (for ResNet architectures only):
#508 states that if the number of input channels to a CNN is different from a pretrained network (eg ImageNet with 3 channels), it should still be able to use pre-trained weights for conv1. 
It accomplishes this for ResNet architectures by copying the mean value of conv1 layer weights across channels to all channels, if the number of channels is not 3. If the number of channels is 3, the original weights are used rather than applying the average value to 3 channels. 