### PR TITLE
Issue #523 AudioMoth 1.5-1.8.1 MetaData

### DIFF
--- a/opensoundscape/audiomoth.py
+++ b/opensoundscape/audiomoth.py
@@ -92,6 +92,7 @@ def parse_audiomoth_metadata(metadata):
             metadata["gain_setting"] = comment.split(" gain setting")[0].split(" ")[-1]
     else:
         metadata["gain_setting"] = comment.split(" gain")[0].split(" ")[-1]
+
     metadata["battery_state"] = _parse_audiomoth_battery_info(comment)
     metadata["audiomoth_id"] = metadata["artist"].split(" ")[1]
     if "temperature" in comment:
@@ -170,7 +171,7 @@ def _parse_audiomoth_battery_info(comment):
     Returns:
         float of voltage or string describing voltage, eg "less than 2.5V"
     """
-    if "state " in comment:
+    if "battery state" in comment:
         battery_str = comment.split("battery state was ")[1].split("V")[0] + "V"
     else:
         battery_str = comment.split("battery was ")[1].split("V")[0] + "V"

--- a/opensoundscape/audiomoth.py
+++ b/opensoundscape/audiomoth.py
@@ -87,6 +87,8 @@ def parse_audiomoth_metadata(metadata):
         metadata["gain_setting"] = int(comment.split("gain setting ")[1][:1])
     except ValueError:
         metadata["gain_setting"] = comment.split(" gain")[0].split(" ")[-1]
+    except IndexError:
+        metadata["gain_setting"] = comment.split(" gain")[0].split(" ")[-1]
     # written "3.2V" or "less than 2.5V" (or? greater than 4.5V?)
     metadata["battery_state"] = _parse_audiomoth_battery_info(comment)
     metadata["audiomoth_id"] = metadata["artist"].split(" ")[1]
@@ -165,7 +167,10 @@ def _parse_audiomoth_battery_info(comment):
     Returns:
         float of voltage or string describing voltage, eg "less than 2.5V"
     """
-    battery_str = comment.split("battery state was ")[1].split("V")[0] + "V"
+    if "state " in comment:
+        battery_str = comment.split("battery state was ")[1].split("V")[0] + "V"
+    else:
+        battery_str = comment.split("battery was ")[1].split("V")[0] + "V"
     if len(battery_str) == 4:
         return float(battery_str[:-1])
     else:

--- a/opensoundscape/audiomoth.py
+++ b/opensoundscape/audiomoth.py
@@ -10,7 +10,7 @@ def audiomoth_start_time(file, filename_timezone="UTC", to_utc=False):
 
     AudioMoths create their file name based on the time that recording starts.
     This function parses the name into a timestamp. Older AudioMoth firmwares
-    used a hexidecimal unix time format, while newer firmwares use a
+    used a hexadecimal unix time format, while newer firmwares use a
     human-readable naming convention. This function handles both conventions.
 
     Args:
@@ -32,7 +32,7 @@ def audiomoth_start_time(file, filename_timezone="UTC", to_utc=False):
     if len(name) == 8:
         # HEX filename convention (old firmware)
         if filename_timezone != "UTC":
-            raise ValueError('hexidecimal file names must have filename_timezone="UTC"')
+           raise ValueError('hexadecimal file names must have filename_timezone="UTC"')
         localized_dt = hex_to_time(Path(file).stem)  # returns UTC localized dt
     elif len(name) == 15:
         # human-readable format (newer firmware)
@@ -57,16 +57,18 @@ def parse_audiomoth_metadata(metadata):
 
     -parses the comment field
     -adds keys for gain_setting, battery_state, recording_start_time
-    -if available (firmware >=1.4.0), addes temperature
+    -if available (firmware >=1.4.0), adds temperature
 
     Notes on comment field:
     - Starting with Firmware 1.4.0, the audiomoth logs Temperature to the
       metadata (wav header) eg "and temperature was 11.2C."
     - At some point the firmware shifted from writing "gain setting 2" to
-      "medium gain setting". Should handle both modes.
+      "medium gain setting" and later to just "medium gain". Should handle both modes.
+    - In later versions of the firmware, "state" was ommitted from "battery state" in 
+      the comment field. Handles either phrasing.
 
     Tested for AudioMoth firmware versions:
-        1.5.0
+        1.5.0 through 1.8.1
 
     Args:
         metadata: dictionary with audiomoth metadata
@@ -83,13 +85,13 @@ def parse_audiomoth_metadata(metadata):
     metadata["recording_start_time"] = _parse_audiomoth_comment_dt(comment)
 
     # gain setting can be written "medium gain" or "gain setting 2"
-    try:
-        metadata["gain_setting"] = int(comment.split("gain setting ")[1][:1])
-    except ValueError:
+    if "gain setting" in comment:
+        try:
+            metadata["gain_setting"] = int(comment.split("gain setting ")[1][:1])
+        except ValueError:
+            metadata["gain_setting"] = comment.split(" gain setting")[0].split(" ")[-1]
+    else:
         metadata["gain_setting"] = comment.split(" gain")[0].split(" ")[-1]
-    except IndexError:
-        metadata["gain_setting"] = comment.split(" gain")[0].split(" ")[-1]
-    # written "3.2V" or "less than 2.5V" (or? greater than 4.5V?)
     metadata["battery_state"] = _parse_audiomoth_battery_info(comment)
     metadata["audiomoth_id"] = metadata["artist"].split(" ")[1]
     if "temperature" in comment:
@@ -161,6 +163,7 @@ def _parse_audiomoth_battery_info(comment):
     ...battery state was 4.7V.
     ...battery state was less than 2.5V
     ...battery state was 3.5V and temperature....
+    ...battery was 4.6V and...
 
     Args:
         comment: the full comment string from an audiomoth metadata Comment field

--- a/opensoundscape/audiomoth.py
+++ b/opensoundscape/audiomoth.py
@@ -32,7 +32,7 @@ def audiomoth_start_time(file, filename_timezone="UTC", to_utc=False):
     if len(name) == 8:
         # HEX filename convention (old firmware)
         if filename_timezone != "UTC":
-           raise ValueError('hexadecimal file names must have filename_timezone="UTC"')
+            raise ValueError('hexadecimal file names must have filename_timezone="UTC"')
         localized_dt = hex_to_time(Path(file).stem)  # returns UTC localized dt
     elif len(name) == 15:
         # human-readable format (newer firmware)
@@ -64,7 +64,7 @@ def parse_audiomoth_metadata(metadata):
       metadata (wav header) eg "and temperature was 11.2C."
     - At some point the firmware shifted from writing "gain setting 2" to
       "medium gain setting" and later to just "medium gain". Should handle both modes.
-    - In later versions of the firmware, "state" was ommitted from "battery state" in 
+    - In later versions of the firmware, "state" was ommitted from "battery state" in
       the comment field. Handles either phrasing.
 
     Tested for AudioMoth firmware versions:

--- a/opensoundscape/audiomoth.py
+++ b/opensoundscape/audiomoth.py
@@ -86,7 +86,7 @@ def parse_audiomoth_metadata(metadata):
     try:
         metadata["gain_setting"] = int(comment.split("gain setting ")[1][:1])
     except ValueError:
-        metadata["gain_setting"] = comment.split(" gain setting")[0].split(" ")[-1]
+        metadata["gain_setting"] = comment.split(" gain")[0].split(" ")[-1]
     # written "3.2V" or "less than 2.5V" (or? greater than 4.5V?)
     metadata["battery_state"] = _parse_audiomoth_battery_info(comment)
     metadata["audiomoth_id"] = metadata["artist"].split(" ")[1]

--- a/tests/test_audiomoth.py
+++ b/tests/test_audiomoth.py
@@ -144,3 +144,30 @@ def test_parse_audiomoth_metadata_with_low_battery():
 def test_parse_audiomoth_from_path_wrong_metadata(veryshort_wav_str):
     with pytest.raises(ValueError):
         audiomoth.parse_audiomoth_metadata_from_path(veryshort_wav_str)
+
+def test_parse_audiomoth_metadata_v16_and_later():
+    metadata = {
+        "filesize": 115200360,
+        "album": None,
+        "albumartist": None,
+        "artist": "AudioMoth 24526B065D325963",
+        "audio_offset": None,
+        "bitrate": 500.0,
+        "channels": 1,
+        "comment": "Recorded at 10:00:00 15/05/2021 (UTC) by AudioMoth 249BC3055C02FE06 at medium gain while battery was 4.5V and temperature was 21.1C. Recording stopped due to switch position change.",
+        "composer": None,
+        "disc": None,
+        "disc_total": None,
+        "duration": 1800.0,
+        "extra": {},
+        "genre": None,
+        "samplerate": 32000,
+        "title": None,
+        "track": None,
+        "track_total": None,
+        "year": None,
+        "audio_offest": 352,
+    }
+    new_metadata = audiomoth.parse_audiomoth_metadata(metadata)
+    assert new_metadata["gain_setting"] == "medium"
+    assert new_metadata["battery_state"] == 4.5

--- a/tests/test_audiomoth.py
+++ b/tests/test_audiomoth.py
@@ -145,6 +145,7 @@ def test_parse_audiomoth_from_path_wrong_metadata(veryshort_wav_str):
     with pytest.raises(ValueError):
         audiomoth.parse_audiomoth_metadata_from_path(veryshort_wav_str)
 
+
 def test_parse_audiomoth_metadata_v16_and_later():
     metadata = {
         "filesize": 115200360,

--- a/tests/test_audiomoth.py
+++ b/tests/test_audiomoth.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pytz
 import pytest
 from opensoundscape import audiomoth
+from math import isclose
 
 
 @pytest.fixture()
@@ -146,7 +147,12 @@ def test_parse_audiomoth_from_path_wrong_metadata(veryshort_wav_str):
         audiomoth.parse_audiomoth_metadata_from_path(veryshort_wav_str)
 
 
-def test_parse_audiomoth_metadata_v16_and_later():
+def test_parse_audiomoth_metadata_v16_to_v181():
+    """Firmware versions 1.6.0 through 1.8.2 (latest release as of Sept. 2022) use this comment syntax
+
+    note the difference between how gain and battery are written
+
+    """
     metadata = {
         "filesize": 115200360,
         "album": None,
@@ -171,4 +177,4 @@ def test_parse_audiomoth_metadata_v16_and_later():
     }
     new_metadata = audiomoth.parse_audiomoth_metadata(metadata)
     assert new_metadata["gain_setting"] == "medium"
-    assert new_metadata["battery_state"] == 4.5
+    assert isclose(new_metadata["battery_state"], 4.5, abs_tol=1e-5)


### PR DESCRIPTION
- Added support for getting AudioMoth metadata incl. comment field for recordings made with firmware versions 1.5-1.8.1
- Fixed typos in comments