### PR TITLE
Handles file with zero annotations

### DIFF
--- a/opensoundscape/annotations.py
+++ b/opensoundscape/annotations.py
@@ -172,11 +172,12 @@ class BoxedAnnotations:
         df = self.df.copy()
 
         # remove annotations that don't overlap with window
-        df = df[
+        df = df.loc[
             [
                 overlap([start_time, end_time], [t0, t1]) > 0
                 for t0, t1 in zip(df["start_time"], df["end_time"])
-            ]
+            ],
+            :,
         ]
 
         if edge_mode == "trim":  # trim boxes to start and end times
@@ -220,11 +221,12 @@ class BoxedAnnotations:
         df = self.df.copy()
 
         # remove annotations that don't overlap with bandpass range
-        df = df[
+        df = df.loc[
             [
                 overlap([low_f, high_f], [f0, f1]) > 0
                 for f0, f1 in zip(df["low_f"], df["high_f"])
-            ]
+            ],
+            :,
         ]
 
         # handle edges
@@ -305,7 +307,7 @@ class BoxedAnnotations:
             classes = np.unique(df["annotation"])
         else:  # the user specified a list of classes
             # subset annotations to user-specified classes
-            df = df[df["annotation"].apply(lambda x: x in classes)]
+            df = df[df["annotation"].isin(classes)]
 
         # if we want to keep the original index, the best way is
         # to store it and add again later

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -266,6 +266,10 @@ def test_one_hot_to_categorical_and_back():
 def test_raven_annotation_methods_empty(raven_file_empty):
     a = BoxedAnnotations.from_raven_file(raven_file_empty, annotation_column="Species")
 
+    a.trim(0, 5)
+    a.bandpass(0, 11025)
+    assert len(a.df) == 0
+
     # test with random parameters to generate clip dataframe
     clip_df = generate_clip_times_df(
         full_duration=10,
@@ -281,10 +285,6 @@ def test_raven_annotation_methods_empty(raven_file_empty):
 
     assert (labels_df.reset_index() == clip_df).all().all()
 
-    a.trim(0, 5)
-    a.bandpass(0, 11025)
-    assert len(a.df) == 0
-
     # classes = subset
     labels_df = a.one_hot_labels_like(
         clip_df,
@@ -294,7 +294,3 @@ def test_raven_annotation_methods_empty(raven_file_empty):
 
     assert len(labels_df) == len(clip_df)
     assert (labels_df.columns == ["Species1", "Species2"]).all()
-
-    a.trim(0, 5)
-    a.bandpass(0, 11025)
-    assert len(a.df) == 0

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -260,3 +260,41 @@ def test_one_hot_to_categorical_and_back():
 
     assert np.array_equal(one_hot, one_hot2)
     assert np.array_equal(classes, classes2)
+
+
+# test robustness of raven methods for empty annotation file
+def test_raven_annotation_methods_empty(raven_file_empty):
+    a = BoxedAnnotations.from_raven_file(raven_file_empty, annotation_column="Species")
+
+    # test with random parameters to generate clip dataframe
+    clip_df = generate_clip_times_df(
+        full_duration=10,
+        clip_duration=2,
+    )
+
+    # classes = None
+    labels_df = a.one_hot_labels_like(
+        clip_df,
+        classes=None,
+        min_label_overlap=0.25,
+    )
+
+    assert (labels_df.reset_index() == clip_df).all().all()
+
+    a.trim(0, 5)
+    a.bandpass(0, 11025)
+    assert len(a.df) == 0
+
+    # classes = subset
+    labels_df = a.one_hot_labels_like(
+        clip_df,
+        classes=["Species1", "Species2"],
+        min_label_overlap=0.25,
+    )
+
+    assert len(labels_df) == len(clip_df)
+    assert (labels_df.columns == ["Species1", "Species2"]).all()
+
+    a.trim(0, 5)
+    a.bandpass(0, 11025)
+    assert len(a.df) == 0


### PR DESCRIPTION
Resolution for Issue #548 with modifications to following `BoxedAnnotation` methods in `annotations.py`

- `one_hot_labels_like`
- `trim`
- `bandpass`