### PR TITLE
Updated `BoxedAnnotations` docstring

### DIFF
--- a/opensoundscape/annotations.py
+++ b/opensoundscape/annotations.py
@@ -11,11 +11,9 @@ from pathlib import Path
 
 class BoxedAnnotations:
     """container for "boxed" (frequency-time) annotations of audio
-
     (for instance, annotations created in Raven software)
-    includes functionality to load annotations from Raven txt files,
-    output one-hot labels for specific clip lengths or clip start/end times,
-    apply corrections/conversions to annotations, and more.
+
+    includes functionality to load annotations from Pandas DataFrame or Raven Selection tables (.txt files), output one-hot labels for specific clip lengths or clip start/end times, apply corrections/conversions to annotations, and more.
 
     Contains some analogous functions to Audio and Spectrogram, such as
     trim() [limit time range] and bandpass() [limit frequency range]
@@ -25,16 +23,16 @@ class BoxedAnnotations:
         """
         create object directly from DataFrame of frequency-time annotations
 
-        For loading annotations from Raven txt files, use from_raven_file()
+        For loading annotations from Raven txt files, use `from_raven_file`
 
         Args:
             df: DataFrame of frequency-time labels. Columns must include:
                 - "annotation": string or numeric labels (can be None/nan)
                 - "start_time": left bound, sec since beginning of audio
                 - "end_time": right bound, sec since beginning of audio
-                - "low_f": upper frequency bound (values can be None/nan)
+                - "low_f": lower frequency bound (values can be None/nan)
                 - "high_f": upper frequency bound (values can be None/nan)
-            audio_file: optionally include the name or path of corresponding
+            audio_file: optionally include the name or path of corresponding audio clip for which annotations are loaded from the DataFrame
 
         Returns:
             BoxedAnnotations object
@@ -49,7 +47,7 @@ class BoxedAnnotations:
         self.audio_file = audio_file
 
     def __repr__(self):
-        return f"<opensoundscape.annotations.BoxedAnnotations object with audio_file={self.audio_file}.>"
+        return f"<opensoundscape.annotations.BoxedAnnotations object with audio_file={self.audio_file}>"
 
     @classmethod
     def from_raven_file(


### PR DESCRIPTION
> Init signature: BoxedAnnotations(df, audio_file=None)
> Docstring:     
> container for "boxed" (frequency-time) annotations of audio
> (for instance, annotations created in Raven software)
> 
> includes functionality to load annotations from Pandas DataFrame or Raven Selection tables (.txt files), output one-hot labels for specific clip lengths or clip start/end times, apply corrections/conversions to annotations, and more.
> 
> Contains some analogous functions to Audio and Spectrogram, such as
> trim() [limit time range] and bandpass() [limit frequency range]
> Init docstring:
> create object directly from DataFrame of frequency-time annotations
> 
> For loading annotations from Raven txt files, use `from_raven_file`
> 
> Args:
>     df: DataFrame of frequency-time labels. Columns must include:
>         - "annotation": string or numeric labels (can be None/nan)
>         - "start_time": left bound, sec since beginning of audio
>         - "end_time": right bound, sec since beginning of audio
>         - "low_f": lower frequency bound (values can be None/nan)
>         - "high_f": upper frequency bound (values can be None/nan)
>     audio_file: optionally include the name or path of corresponding audio clip for which annotations are loaded from the DataFrame
> 
> Returns:
>     BoxedAnnotations object
> File:           ~/repos/opensoundscape/opensoundscape/annotations.py
> Type:           type
> Subclasses:     