### PR TITLE
resolves #614 - avoid bug in load channels of mono

### DIFF
--- a/opensoundscape/audio.py
+++ b/opensoundscape/audio.py
@@ -635,6 +635,8 @@ def load_channels_as_audio(
         duration=duration,
     )
     warnings.resetwarnings()
+    if len(np.shape(samples)) == 1:
+        samples = [samples]
     audio_objects = [
         Audio(samples=samples_channel, sample_rate=sr, resample_type=resample_type)
         for samples_channel in samples

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -119,6 +119,14 @@ def test_load_channels_as_audio(stereo_wav_str):
     s = load_channels_as_audio(stereo_wav_str)
     assert max(s[0].samples) == 0  # channel 1 of stereo.wav is all 0
     assert max(s[1].samples) == 1  # channel 2 of stereo.wav is all 1
+    assert len(s) == 2
+    assert type(s[0]) == Audio
+
+
+def test_load_channels_as_audio_from_mono(veryshort_wav_str):
+    s = load_channels_as_audio(veryshort_wav_str)
+    assert len(s) == 1
+    assert type(s[0]) == Audio
 
 
 def test_load_incorrect_timestamp(onemin_wav_str):


### PR DESCRIPTION
Since librosa.load returns a variable of different shape when loading 1-channel vs multiple channel audio files with mono=False, attempting to use load_channels_as_audio on a file with one channel gave an error. This commit fixes the error and adds a test.