### PR TITLE
log top-scoring samples to wandb (resolves #575)

### DIFF
--- a/opensoundscape/torch/datasets.py
+++ b/opensoundscape/torch/datasets.py
@@ -196,3 +196,5 @@ class AudioSplittingDataset(AudioFileDataset):
         self.label_df = clip_times_df.reset_index().set_index(
             ["file", "start_time", "end_time"]
         )[[]]
+
+        self.has_clips = True


### PR DESCRIPTION
This PR adds logging of highest n scoring clips per class to WandB after running model.predict()
- defaults to 3 clips per class for up to 5 classes
- moves wandb sample logging configuration to model.wandb_logging dictionary with 3 parameters: "n_preview_samples" (number of samples to log to wandb before training/prediction); "top_samples_classes": which classes to log top-scoring samples of after prediction (if None, first 5 classes or all if less than 5); "n_top_samples": how many top-scoring samples to log for each class

It also resolves a bug by setting self.has_clips=True in AudioSplittingDataset initialization. It should be True, but was False because of the way it was initialized and oversight when writing the code. 
