### PR TITLE
Feat 478 efficientnet and refactor cnn_architectures

### DIFF
--- a/opensoundscape/torch/architectures/cnn_architectures.py
+++ b/opensoundscape/torch/architectures/cnn_architectures.py
@@ -466,7 +466,7 @@ def efficientnet_b0(
     architecture_ft = torch.hub.load(
         "NVIDIA/DeepLearningExamples:torchhub",
         "nvidia_efficientnet_b0",
-        pretrained=use_pretrained,
+        weights="IMAGENET1K_V1" if use_pretrained else None,
     )
 
     # prevent weights of feature extractor from being trained, if desired
@@ -508,7 +508,7 @@ def efficientnet_b4(
     architecture_ft = torch.hub.load(
         "NVIDIA/DeepLearningExamples:torchhub",
         "nvidia_efficientnet_b4",
-        pretrained=use_pretrained,
+        weights="IMAGENET1K_V1" if use_pretrained else None,
     )
 
     # prevent weights of feature extractor from being trained, if desired
@@ -550,7 +550,7 @@ def efficientnet_widese_b0(
     architecture_ft = torch.hub.load(
         "NVIDIA/DeepLearningExamples:torchhub",
         "nvidia_efficientnet_widese_b0",
-        pretrained=use_pretrained,
+        weights="IMAGENET1K_V1" if use_pretrained else None,
     )
 
     # prevent weights of feature extractor from being trained, if desired
@@ -592,7 +592,7 @@ def efficientnet_widese_b4(
     architecture_ft = torch.hub.load(
         "NVIDIA/DeepLearningExamples:torchhub",
         "nvidia_efficientnet_widese_b4",
-        pretrained=use_pretrained,
+        weights="IMAGENET1K_V1" if use_pretrained else None,
     )
 
     # prevent weights of feature extractor from being trained, if desired

--- a/opensoundscape/torch/architectures/cnn_architectures.py
+++ b/opensoundscape/torch/architectures/cnn_architectures.py
@@ -463,6 +463,7 @@ def efficientnet_b0(
             specify channels in input sample, eg [channels h,w] sample shape
 
     """
+    torch.hub._validate_not_a_forked_repo = lambda a, b, c: True
     architecture_ft = torch.hub.load(
         "NVIDIA/DeepLearningExamples:torchhub",
         "nvidia_efficientnet_b0",
@@ -505,6 +506,7 @@ def efficientnet_b4(
             specify channels in input sample, eg [channels h,w] sample shape
 
     """
+    torch.hub._validate_not_a_forked_repo=lambda a,b,c: True
     architecture_ft = torch.hub.load(
         "NVIDIA/DeepLearningExamples:torchhub",
         "nvidia_efficientnet_b4",
@@ -547,6 +549,7 @@ def efficientnet_widese_b0(
             specify channels in input sample, eg [channels h,w] sample shape
 
     """
+    torch.hub._validate_not_a_forked_repo=lambda a,b,c: True
     architecture_ft = torch.hub.load(
         "NVIDIA/DeepLearningExamples:torchhub",
         "nvidia_efficientnet_widese_b0",
@@ -589,6 +592,7 @@ def efficientnet_widese_b4(
             specify channels in input sample, eg [channels h,w] sample shape
 
     """
+    torch.hub._validate_not_a_forked_repo=lambda a,b,c: True
     architecture_ft = torch.hub.load(
         "NVIDIA/DeepLearningExamples:torchhub",
         "nvidia_efficientnet_widese_b4",

--- a/opensoundscape/torch/architectures/cnn_architectures.py
+++ b/opensoundscape/torch/architectures/cnn_architectures.py
@@ -466,7 +466,7 @@ def efficientnet_b0(
     architecture_ft = torch.hub.load(
         "NVIDIA/DeepLearningExamples:torchhub",
         "nvidia_efficientnet_b0",
-        weights="IMAGENET1K_V1" if use_pretrained else None,
+        pretrained=use_pretrained,
     )
 
     # prevent weights of feature extractor from being trained, if desired
@@ -508,7 +508,7 @@ def efficientnet_b4(
     architecture_ft = torch.hub.load(
         "NVIDIA/DeepLearningExamples:torchhub",
         "nvidia_efficientnet_b4",
-        weights="IMAGENET1K_V1" if use_pretrained else None,
+        pretrained=use_pretrained,
     )
 
     # prevent weights of feature extractor from being trained, if desired
@@ -550,7 +550,7 @@ def efficientnet_widese_b0(
     architecture_ft = torch.hub.load(
         "NVIDIA/DeepLearningExamples:torchhub",
         "nvidia_efficientnet_widese_b0",
-        weights="IMAGENET1K_V1" if use_pretrained else None,
+        pretrained=use_pretrained,
     )
 
     # prevent weights of feature extractor from being trained, if desired
@@ -592,7 +592,7 @@ def efficientnet_widese_b4(
     architecture_ft = torch.hub.load(
         "NVIDIA/DeepLearningExamples:torchhub",
         "nvidia_efficientnet_widese_b4",
-        weights="IMAGENET1K_V1" if use_pretrained else None,
+        pretrained=use_pretrained,
     )
 
     # prevent weights of feature extractor from being trained, if desired
@@ -683,10 +683,6 @@ def change_conv2d_channels(
             Pytorch's model zoo.
         num_channels:
             specify channels in input sample, eg [channels h,w] sample shape
-        torchhub_entrypoint:
-            Choose torchhub architecture from ['nvidia_efficientnet_b0',
-            'nvidia_efficientnet_b4','nvidia_efficientnet_widese_b0',
-            'nvidia_efficientnet_widese_b4']. [default: nvidia_efficientnet_b4]
         reuse_weights: if True (default), averages (if num_channels<original)
         or cycles through (if num_channels>original) original channel weights
             and adds them to the new Conv2D

--- a/opensoundscape/torch/architectures/cnn_architectures.py
+++ b/opensoundscape/torch/architectures/cnn_architectures.py
@@ -444,6 +444,174 @@ def inception_v3(
     return architecture_ft
 
 
+@register_arch
+def efficientnet_b0(
+    num_classes, freeze_feature_extractor=False, use_pretrained=True, num_channels=3
+):
+    """Wrapper for efficientnet_b0 architecture
+
+    Args:
+        num_classes:
+            number of output nodes for the final layer
+        freeze_feature_extractor:
+            if False (default), entire network will have gradients and can train
+            if True, feature block is frozen and only final layer is trained
+        use_pretrained:
+            if True, uses pre-trained ImageNet features from
+            Pytorch's model zoo.
+        num_channels:
+            specify channels in input sample, eg [channels h,w] sample shape
+
+    """
+    architecture_ft = torch.hub.load(
+        "NVIDIA/DeepLearningExamples:torchhub",
+        "nvidia_efficientnet_b0",
+        pretrained=use_pretrained,
+    )
+
+    # prevent weights of feature extractor from being trained, if desired
+    if freeze_feature_extractor:
+        freeze_params(architecture_ft)
+
+    # change number of output nodes
+    architecture_ft.classifier.fc = change_fc_output_size(
+        architecture_ft.classifier.fc, num_classes
+    )
+
+    # change input shape num_channels
+    architecture_ft.stem.conv = change_conv2d_channels(
+        architecture_ft.stem.conv, num_channels
+    )
+
+    return architecture_ft
+
+
+@register_arch
+def efficientnet_b4(
+    num_classes, freeze_feature_extractor=False, use_pretrained=True, num_channels=3
+):
+    """Wrapper for efficientnet_b4 architecture
+
+    Args:
+        num_classes:
+            number of output nodes for the final layer
+        freeze_feature_extractor:
+            if False (default), entire network will have gradients and can train
+            if True, feature block is frozen and only final layer is trained
+        use_pretrained:
+            if True, uses pre-trained ImageNet features from
+            Pytorch's model zoo.
+        num_channels:
+            specify channels in input sample, eg [channels h,w] sample shape
+
+    """
+    architecture_ft = torch.hub.load(
+        "NVIDIA/DeepLearningExamples:torchhub",
+        "nvidia_efficientnet_b4",
+        pretrained=use_pretrained,
+    )
+
+    # prevent weights of feature extractor from being trained, if desired
+    if freeze_feature_extractor:
+        freeze_params(architecture_ft)
+
+    # change number of output nodes
+    architecture_ft.classifier.fc = change_fc_output_size(
+        architecture_ft.classifier.fc, num_classes
+    )
+
+    # change input shape num_channels
+    architecture_ft.stem.conv = change_conv2d_channels(
+        architecture_ft.stem.conv, num_channels
+    )
+
+    return architecture_ft
+
+
+@register_arch
+def efficientnet_widese_b0(
+    num_classes, freeze_feature_extractor=False, use_pretrained=True, num_channels=3
+):
+    """Wrapper for efficientnet_widese_b0 architecture
+
+    Args:
+        num_classes:
+            number of output nodes for the final layer
+        freeze_feature_extractor:
+            if False (default), entire network will have gradients and can train
+            if True, feature block is frozen and only final layer is trained
+        use_pretrained:
+            if True, uses pre-trained ImageNet features from
+            Pytorch's model zoo.
+        num_channels:
+            specify channels in input sample, eg [channels h,w] sample shape
+
+    """
+    architecture_ft = torch.hub.load(
+        "NVIDIA/DeepLearningExamples:torchhub",
+        "nvidia_efficientnet_widese_b0",
+        pretrained=use_pretrained,
+    )
+
+    # prevent weights of feature extractor from being trained, if desired
+    if freeze_feature_extractor:
+        freeze_params(architecture_ft)
+
+    # change number of output nodes
+    architecture_ft.classifier.fc = change_fc_output_size(
+        architecture_ft.classifier.fc, num_classes
+    )
+
+    # change input shape num_channels
+    architecture_ft.stem.conv = change_conv2d_channels(
+        architecture_ft.stem.conv, num_channels
+    )
+
+    return architecture_ft
+
+
+@register_arch
+def efficientnet_widese_b4(
+    num_classes, freeze_feature_extractor=False, use_pretrained=True, num_channels=3
+):
+    """Wrapper for efficientnet_widese_b4 architecture
+
+    Args:
+        num_classes:
+            number of output nodes for the final layer
+        freeze_feature_extractor:
+            if False (default), entire network will have gradients and can train
+            if True, feature block is frozen and only final layer is trained
+        use_pretrained:
+            if True, uses pre-trained ImageNet features from
+            Pytorch's model zoo.
+        num_channels:
+            specify channels in input sample, eg [channels h,w] sample shape
+
+    """
+    architecture_ft = torch.hub.load(
+        "NVIDIA/DeepLearningExamples:torchhub",
+        "nvidia_efficientnet_widese_b4",
+        pretrained=use_pretrained,
+    )
+
+    # prevent weights of feature extractor from being trained, if desired
+    if freeze_feature_extractor:
+        freeze_params(architecture_ft)
+
+    # change number of output nodes
+    architecture_ft.classifier.fc = change_fc_output_size(
+        architecture_ft.classifier.fc, num_classes
+    )
+
+    # change input shape num_channels
+    architecture_ft.stem.conv = change_conv2d_channels(
+        architecture_ft.stem.conv, num_channels
+    )
+
+    return architecture_ft
+
+
 # @register_arch
 # def efficientnet(
 #     num_classes,

--- a/opensoundscape/torch/architectures/cnn_architectures.py
+++ b/opensoundscape/torch/architectures/cnn_architectures.py
@@ -506,7 +506,7 @@ def efficientnet_b4(
             specify channels in input sample, eg [channels h,w] sample shape
 
     """
-    torch.hub._validate_not_a_forked_repo=lambda a,b,c: True
+    torch.hub._validate_not_a_forked_repo = lambda a, b, c: True
     architecture_ft = torch.hub.load(
         "NVIDIA/DeepLearningExamples:torchhub",
         "nvidia_efficientnet_b4",
@@ -549,7 +549,7 @@ def efficientnet_widese_b0(
             specify channels in input sample, eg [channels h,w] sample shape
 
     """
-    torch.hub._validate_not_a_forked_repo=lambda a,b,c: True
+    torch.hub._validate_not_a_forked_repo = lambda a, b, c: True
     architecture_ft = torch.hub.load(
         "NVIDIA/DeepLearningExamples:torchhub",
         "nvidia_efficientnet_widese_b0",
@@ -592,7 +592,7 @@ def efficientnet_widese_b4(
             specify channels in input sample, eg [channels h,w] sample shape
 
     """
-    torch.hub._validate_not_a_forked_repo=lambda a,b,c: True
+    torch.hub._validate_not_a_forked_repo = lambda a, b, c: True
     architecture_ft = torch.hub.load(
         "NVIDIA/DeepLearningExamples:torchhub",
         "nvidia_efficientnet_widese_b4",

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -4,6 +4,8 @@ from opensoundscape.torch.loss import ResampleLoss
 from opensoundscape.torch.models import cnn
 
 from opensoundscape.torch.architectures.cnn_architectures import alexnet, resnet18
+from opensoundscape.torch.architectures import cnn_architectures
+
 from opensoundscape.helpers import make_clip_df
 import pandas as pd
 from pathlib import Path
@@ -129,6 +131,48 @@ def test_predict_on_list_of_files(test_df):
     model = cnn.CNN("resnet18", classes=[0, 1], sample_duration=5.0)
     scores, preds, _ = model.predict(test_df.index.values)
     assert len(scores) == 2
+
+
+def test_predict_all_arch_4ch(test_df):
+    for arch_name in cnn_architectures.ARCH_DICT.keys():
+        try:
+            arch = cnn_architectures.ARCH_DICT[arch_name](num_classes=2, num_channels=4)
+            if "inception" in arch_name:
+                model = cnn.InceptionV3(
+                    classes=[0, 1], sample_duration=5.0, sample_shape=[224, 224, 4]
+                )
+            else:
+                model = cnn.CNN(
+                    arch,
+                    classes=[0, 1],
+                    sample_duration=5.0,
+                    sample_shape=[224, 224, 4],
+                )
+            scores, _, _ = model.predict(test_df.index.values)
+            assert len(scores) == 2
+        except:
+            raise Exception(f"{arch_name} failed")
+
+
+def test_predict_all_arch_1ch(test_df):
+    for arch_name in cnn_architectures.ARCH_DICT.keys():
+        try:
+            arch = cnn_architectures.ARCH_DICT[arch_name](num_classes=2, num_channels=1)
+            if "inception" in arch_name:
+                model = cnn.InceptionV3(
+                    classes=[0, 1], sample_duration=5.0, sample_shape=[224, 224, 4]
+                )
+            else:
+                model = cnn.CNN(
+                    arch,
+                    classes=[0, 1],
+                    sample_duration=5.0,
+                    sample_shape=[224, 224, ],
+                )
+            scores, preds, _ = model.predict(test_df.index.values)
+            assert len(scores) == 2
+        except:
+            raise Exception(f"{arch_name} failed")
 
 
 def test_predict_on_clip_df(test_df):

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -167,7 +167,7 @@ def test_predict_all_arch_1ch(test_df):
                     arch,
                     classes=[0, 1],
                     sample_duration=5.0,
-                    sample_shape=[224, 224, ],
+                    sample_shape=[224, 224, 1],
                 )
             scores, preds, _ = model.predict(test_df.index.values)
             assert len(scores) == 2

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -136,7 +136,9 @@ def test_predict_on_list_of_files(test_df):
 def test_predict_all_arch_4ch(test_df):
     for arch_name in cnn_architectures.ARCH_DICT.keys():
         try:
-            arch = cnn_architectures.ARCH_DICT[arch_name](num_classes=2, num_channels=4)
+            arch = cnn_architectures.ARCH_DICT[arch_name](
+                num_classes=2, num_channels=4, use_pretrained=False
+            )
             if "inception" in arch_name:
                 model = cnn.InceptionV3(
                     classes=[0, 1], sample_duration=5.0, sample_shape=[224, 224, 4]
@@ -157,7 +159,9 @@ def test_predict_all_arch_4ch(test_df):
 def test_predict_all_arch_1ch(test_df):
     for arch_name in cnn_architectures.ARCH_DICT.keys():
         try:
-            arch = cnn_architectures.ARCH_DICT[arch_name](num_classes=2, num_channels=1)
+            arch = cnn_architectures.ARCH_DICT[arch_name](
+                num_classes=2, num_channels=1, use_pretrained=False
+            )
             if "inception" in arch_name:
                 model = cnn.InceptionV3(
                     classes=[0, 1], sample_duration=5.0, sample_shape=[224, 224, 4]

--- a/tests/test_cnn_architectures.py
+++ b/tests/test_cnn_architectures.py
@@ -1,6 +1,9 @@
 from opensoundscape.torch.architectures import cnn_architectures
 import pytest
 
+# test_cnn.py tests that all registered architectures are able to
+# predict on a sample (with modified input channels and output size)
+
 
 def test_freeze_feature_extractor():
     """should disable grad on featur extractor but not classifier"""
@@ -9,8 +12,8 @@ def test_freeze_feature_extractor():
     assert arch.fc.parameters().__next__().requires_grad
 
 
-def test_modify_resnet():
-    """test modifying number of output nodes"""
+def test_modify_out_shape():
+    """test modifying number of output nodes (classes)"""
     arch = cnn_architectures.resnet18(10)
     assert arch.fc.out_features == 10
 

--- a/tests/test_cnn_architectures.py
+++ b/tests/test_cnn_architectures.py
@@ -70,6 +70,22 @@ def test_use_pretrained():
     arch = cnn_architectures.resnet101(4, use_pretrained=True)
 
 
+def test_efficientnet_b0():
+    arch = cnn_architectures.efficientnet_b0(2, use_pretrained=False)
+
+
+def test_efficientnet_b4():
+    arch = cnn_architectures.efficientnet_b4(2, use_pretrained=False)
+
+
+def test_efficientnet_widese_b0():
+    arch = cnn_architectures.efficientnet_widese_b0(2, use_pretrained=False)
+
+
+def test_efficientnet_widese_b4():
+    arch = cnn_architectures.efficientnet_widese_b4(2, use_pretrained=False)
+
+
 def test_noninteger_output_nodes():
     with pytest.raises(TypeError):
         arch = cnn_architectures.resnet101(4.5)


### PR DESCRIPTION
Resolves #478 by adding EfficientNet to cnn_architectures. Also refactors cnn_architectures to consistently re-use weights when possible when reshaping the input conv2d layer of a model and consistently re-shape a final fully connected layer using helper functions. 

Note new behavior for reshaping first conv2d layer's number of channels
- if new # channels less than original, each channel gets weights averaged across all the original channels
- if new # channels is more than the original, each individual original channel is copied 1 or more times until all new channels have weights from one of the original channels
- inception architecture will have random weights if number of input channels changes from 3