### PR TITLE
Feat 569 audio

### DIFF
--- a/opensoundscape/audio.py
+++ b/opensoundscape/audio.py
@@ -552,15 +552,6 @@ class Audio:
                         if field in self.metadata and self.metadata[field] is not None:
                             s.__setattr__(field, self.metadata[field])
 
-    def duration(self):
-        """Return duration of Audio
-
-        Returns:
-            duration (float): The duration of the Audio
-        """
-
-        return len(self.samples) / self.sample_rate
-
     def split(self, clip_duration, clip_overlap=0, final_clip=None):
         """Split Audio into even-lengthed clips
 
@@ -587,7 +578,7 @@ class Audio:
                 f"or None. Got {final_clip}."
             )
 
-        duration = self.duration()
+        duration = self.duration
         clip_df = generate_clip_times_df(
             full_duration=duration,
             clip_duration=clip_duration,
@@ -666,6 +657,21 @@ class Audio:
         df.index = clip_names
         df.index.name = "file"
         return df
+
+    @property
+    def duration(self):
+        """Calculates the Audio duration in seconds"""
+        return len(self.samples) / self.sample_rate
+
+    @property
+    def rms(self):
+        """Calculates the root-mean-square value of the audio samples"""
+        return np.sqrt(np.mean(self.samples**2))
+
+    @property
+    def dBFS(self):
+        """calculate the root-mean-square dB value relative to a full-scale sine wave"""
+        return 20 * np.log10(self.rms * np.sqrt(2))
 
 
 def load_channels_as_audio(

--- a/opensoundscape/preprocess/actions.py
+++ b/opensoundscape/preprocess/actions.py
@@ -191,20 +191,20 @@ def trim_audio(audio, _sample_duration, extend=True, random_trim=False, tol=1e-5
         raise ValueError("recieved zero-length audio")
 
     if _sample_duration is not None:
-        if audio.duration() + tol <= _sample_duration:
+        if audio.duration + tol <= _sample_duration:
             # input audio is not as long as desired length
             if extend:  # extend clip sith silence
                 audio = audio.extend(_sample_duration)
             else:
                 raise ValueError(
-                    f"the length of the original file ({audio.duration()} "
+                    f"the length of the original file ({audio.duration} "
                     f"sec) was less than the length to extract "
                     f"({_sample_duration} sec). To extend short "
                     f"clips, use extend=True"
                 )
         if random_trim:
             # uniformly randomly choose clip time from full audio
-            extra_time = audio.duration() - _sample_duration
+            extra_time = audio.duration - _sample_duration
             start_time = np.random.uniform() * extra_time
         else:
             start_time = 0

--- a/opensoundscape/ribbit.py
+++ b/opensoundscape/ribbit.py
@@ -139,7 +139,7 @@ def ribbit(
 
     """
     if final_clip == "extend":
-        raise ValuseError(
+        raise ValueError(
             "final_clip='extend' is not supported for RIBBIT. "
             "consider using 'remainder'."
         )
@@ -149,11 +149,11 @@ def ribbit(
     time = spectrogram.times
     # we calculate the sample rate of the amplitude signal using the difference
     # in time between columns of the Spectrogram
-    sample_rate = 1 / spectrogram.window_step()
+    sample_rate = 1 / spectrogram.window_step
 
     # determine the start and end times of each clip to analyze
     clip_df = generate_clip_times_df(
-        full_duration=spectrogram.duration(),
+        full_duration=spectrogram.duration,
         clip_duration=clip_duration,
         clip_overlap=clip_overlap,
         final_clip=final_clip,

--- a/opensoundscape/signal_processing.py
+++ b/opensoundscape/signal_processing.py
@@ -85,7 +85,7 @@ def cwt_peaks(
     x = x / np.max(x)
 
     # calcualte time vector for each point in cwt signal
-    t = np.linspace(0, audio.duration(), len(x))
+    t = np.linspace(0, audio.duration, len(x))
 
     ## find peaks in cwt signal ##
 
@@ -335,7 +335,7 @@ def detect_peak_sequence_cwt(
     dfs = []
 
     # analyze the audio in analysis windows of length winidow_len seconds
-    for window_idx in range(int(audio.duration() / window_len)):
+    for window_idx in range(int(audio.duration / window_len)):
         window_start_t = window_idx * window_len
 
         # trim audio to an analysis window

--- a/opensoundscape/spectrogram.py
+++ b/opensoundscape/spectrogram.py
@@ -224,6 +224,7 @@ class Spectrogram:
     def __repr__(self):
         return f"<Spectrogram(spectrogram={self.spectrogram.shape}, frequencies={self.frequencies.shape}, times={self.times.shape})>"
 
+    @property
     def duration(self):
         """calculate the ammount of time represented in the spectrogram
 
@@ -232,8 +233,8 @@ class Spectrogram:
         such that some samples from the end of the original audio were
         discarded
         """
-        window_length = self.window_length()
-        if window_length is None:
+        window_length = self.window_length
+        if self.window_length is None:
             warnings.warn(
                 "spectrogram must have window_length attribute to"
                 " accurately calculate duration. Approximating duration."
@@ -242,12 +243,14 @@ class Spectrogram:
         else:
             return self.times[-1] + window_length / 2
 
+    @property
     def window_length(self):
         """calculate length of a single fft window, in seconds:"""
         if self.window_samples and self.audio_sample_rate:
             return float(self.window_samples) / self.audio_sample_rate
         return None
 
+    @property
     def window_step(self):
         """calculate time difference (sec) between consecutive windows' centers"""
         if self.window_samples and self.overlap_samples and self.audio_sample_rate:
@@ -257,9 +260,10 @@ class Spectrogram:
             )
         return None
 
+    @property
     def window_start_times(self):
         """get start times of each window, rather than midpoint times"""
-        window_length = self.window_length()
+        window_length = self.window_length
         if window_length is not None:
             return np.array(self.times) - window_length / 2
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -62,20 +62,20 @@ def test_audio_clip_loader_resample(short_wav_path):
 def test_audio_clip_loader_clip(audio_10s_path):
     action = actions.AudioClipLoader()
     audio = action.go(audio_10s_path, _start_time=0, _end_time=2)
-    assert isclose(audio.duration(), 2, abs_tol=1e-4)
+    assert isclose(audio.duration, 2, abs_tol=1e-4)
 
 
 def test_action_trim(audio_short):
     action = actions.AudioTrim()
     audio = action.go(audio_short, _sample_duration=1.0)
-    assert isclose(audio.duration(), 1.0, abs_tol=1e-4)
+    assert isclose(audio.duration, 1.0, abs_tol=1e-4)
 
 
 def test_action_random_trim(audio_short):
     action = actions.AudioTrim(random_trim=True)
     a = action.go(audio_short, _sample_duration=0.01)
     a2 = action.go(audio_short, _sample_duration=0.01)
-    assert isclose(a.duration(), 0.01, abs_tol=1e-4)
+    assert isclose(a.duration, 0.01, abs_tol=1e-4)
     assert not np.array_equal(a.samples, a2.samples)
 
 
@@ -83,7 +83,7 @@ def test_audio_trimmer_default(audio_10s):
     """should not trim if no extra args"""
     action = actions.AudioTrim()
     audio = action.go(audio_10s, _sample_duration=None)
-    assert isclose(audio.duration(), 10, abs_tol=1e-4)
+    assert isclose(audio.duration, 10, abs_tol=1e-4)
 
 
 def test_audio_trimmer_raises_error_on_short_clip(audio_short):
@@ -95,7 +95,7 @@ def test_audio_trimmer_raises_error_on_short_clip(audio_short):
 def test_audio_trimmer_extend_short_clip(audio_short):
     action = actions.AudioTrim()
     audio = action.go(audio_short, _sample_duration=1.0)  # extend=True is default
-    assert isclose(audio.duration(), 1.0, abs_tol=1e-4)
+    assert isclose(audio.duration, 1.0, abs_tol=1e-4)
 
 
 def test_color_jitter(tensor):

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -134,6 +134,10 @@ def test_load_channels_as_audio_from_mono(veryshort_wav_str):
     assert type(s[0]) == Audio
 
 
+def test_duration(veryshort_wav_audio):
+    assert isclose(veryshort_wav_audio.duration, 0.14208616780045352, abs_tol=1e-7)
+
+
 def test_normalize(veryshort_wav_audio):
     assert isclose(
         max(abs(veryshort_wav_audio.normalize(peak_level=0.5).samples)),
@@ -270,41 +274,47 @@ def test_load_metadata(veryshort_wav_str):
 #         a=Audio.from_file(path_with_no_metadata)
 
 
+def test_calculate_rms(veryshort_wav_audio):
+    assert isclose(veryshort_wav_audio.rms, 0.0871002, abs_tol=1e-7)
+
+
+def test_calculate_dBFS(veryshort_wav_audio):
+    assert isclose(veryshort_wav_audio.dBFS, -18.189316963185377, abs_tol=1e-5)
+
+
 def test_property_trim_length_is_correct(silence_10s_mp3_str):
     audio = Audio.from_file(silence_10s_mp3_str, sample_rate=10000)
-    duration = audio.duration()
+    duration = audio.duration
     for _ in range(100):
         [first, second] = sorted([uniform(0, duration), uniform(0, duration)])
-        assert isclose(
-            audio.trim(first, second).duration(), second - first, abs_tol=1e-4
-        )
+        assert isclose(audio.trim(first, second).duration, second - first, abs_tol=1e-4)
 
 
 def test_trim_from_negative_time(silence_10s_mp3_str):
     """correct behavior is to trim from time zero"""
     audio = Audio.from_file(silence_10s_mp3_str, sample_rate=10000).trim(-1, 5)
-    assert isclose(audio.duration(), 5, abs_tol=1e-5)
+    assert isclose(audio.duration, 5, abs_tol=1e-5)
 
 
 def test_trim_past_end_of_clip(silence_10s_mp3_str):
     """correct behavior is to trim to the end of the clip"""
     audio = Audio.from_file(silence_10s_mp3_str, sample_rate=10000).trim(9, 11)
-    assert isclose(audio.duration(), 1, abs_tol=1e-5)
+    assert isclose(audio.duration, 1, abs_tol=1e-5)
 
 
 def test_resample_veryshort_wav(veryshort_wav_str):
     audio = Audio.from_file(veryshort_wav_str)
-    dur = audio.duration()
+    dur = audio.duration
     resampled_audio = audio.resample(22050)
-    assert resampled_audio.duration() == dur
+    assert resampled_audio.duration == dur
     assert resampled_audio.samples.shape == (3133,)
 
 
 def test_resample_mp3_nonstandard_sr(silence_10s_mp3_str):
     audio = Audio.from_file(silence_10s_mp3_str, sample_rate=10000)
-    dur = audio.duration()
+    dur = audio.duration
     resampled_audio = audio.resample(5000)
-    assert resampled_audio.duration() == dur
+    assert resampled_audio.duration == dur
     assert resampled_audio.sample_rate == 5000
 
 
@@ -317,11 +327,11 @@ def test_resample_classmethod_vs_instancemethod(silence_10s_mp3_str):
 
 def test_extend_length_is_correct(silence_10s_mp3_str):
     audio = Audio.from_file(silence_10s_mp3_str, sample_rate=10000)
-    duration = audio.duration()
+    duration = audio.duration
     for _ in range(100):
         extend_length = uniform(duration, duration * 10)
         assert isclose(
-            audio.extend(extend_length).duration(), extend_length, abs_tol=1e-4
+            audio.extend(extend_length).duration, extend_length, abs_tol=1e-4
         )
 
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -44,6 +44,11 @@ def veryshort_wav_str():
 
 
 @pytest.fixture()
+def veryshort_wav_audio(veryshort_wav_str):
+    return Audio.from_file(veryshort_wav_str)
+
+
+@pytest.fixture()
 def silence_10s_mp3_str():
     return "tests/audio/silence_10s.mp3"
 
@@ -127,6 +132,25 @@ def test_load_channels_as_audio_from_mono(veryshort_wav_str):
     s = load_channels_as_audio(veryshort_wav_str)
     assert len(s) == 1
     assert type(s[0]) == Audio
+
+
+def test_normalize(veryshort_wav_audio):
+    assert isclose(
+        max(abs(veryshort_wav_audio.normalize(peak_level=0.5).samples)),
+        0.5,
+        abs_tol=1e-4,
+    )
+
+
+def test_normalize_by_db(veryshort_wav_audio):
+    assert isclose(
+        max(abs(veryshort_wav_audio.normalize(peak_dBFS=0).samples)), 1, abs_tol=1e-4
+    )
+
+
+def test_normalize_doesnt_allow_both_arguments(veryshort_wav_audio):
+    with pytest.raises(ValueError):
+        veryshort_wav_audio.normalize(peak_dBFS=0, peak_level=0.2)
 
 
 def test_load_incorrect_timestamp(onemin_wav_str):

--- a/tests/test_spectrogram.py
+++ b/tests/test_spectrogram.py
@@ -37,10 +37,10 @@ def test_spectrogram_shape_of_veryshort(veryshort_wav_str):
     assert spec.spectrogram.shape == (257, 21)
     assert spec.frequencies.shape == (257,)
     assert spec.times.shape == (21,)
-    assert isclose(spec.window_length(), 0.02321995465, abs_tol=1e-4)
-    assert isclose(spec.window_step(), 0.005804988662, abs_tol=1e-4)
-    assert isclose(spec.duration(), audio.duration(), abs_tol=1e-2)
-    assert isclose(spec.window_start_times()[0], 0, abs_tol=1e-4)
+    assert isclose(spec.window_length, 0.02321995465, abs_tol=1e-4)
+    assert isclose(spec.window_step, 0.005804988662, abs_tol=1e-4)
+    assert isclose(spec.duration, audio.duration, abs_tol=1e-2)
+    assert isclose(spec.window_start_times[0], 0, abs_tol=1e-4)
 
 
 def test_spectrogram_shape_of_windowlengths_overlapfraction(veryshort_wav_str):


### PR DESCRIPTION
resolves #569 by adding Audio.normalize. Also adds Audio.rms and Audio.dBFS. 

Changes several Audio and Spectrogram methods to properties, which is a breaking change. For instance, now `Audio.duration` is correct and `Audio.duration()` will throw an error. 