### PR TITLE
add json comment-string metadata support

### DIFF
--- a/opensoundscape/audiomoth.py
+++ b/opensoundscape/audiomoth.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import datetime
 
 import pytz
-from opensoundscape.helpers import hex_to_time, _load_metadata
+from opensoundscape.helpers import hex_to_time, load_metadata
 
 
 def audiomoth_start_time(file, filename_timezone="UTC", to_utc=False):
@@ -103,7 +103,7 @@ def parse_audiomoth_metadata(metadata):
 
 def parse_audiomoth_metadata_from_path(file_path):
     """Wrapper function to parse audiomoth metadata from file path"""
-    metadata = _load_metadata(file_path)
+    metadata = load_metadata(file_path)
 
     if metadata is None:
         raise ValueError(f"{file_path} does not contain metadata")

--- a/opensoundscape/helpers.py
+++ b/opensoundscape/helpers.py
@@ -132,7 +132,7 @@ def jitter(x, width, distribution="gaussian"):
     )
 
 
-def _load_metadata(path, raise_exceptions=False):
+def load_metadata(path, raise_exceptions=False):
     """use soundfile to load metadata from WAV or AIFF file
 
     Args:


### PR DESCRIPTION
Resolves #565 
Audio save and load now supports (and uses by default) writing .metadata dictionary to a json string in the "comment" field of the standard WAV file metadata. We can add new versioned standards for the content of the "opso_metadata" JSON, I've named the current one "v0.1". It prepends the string "opso_metadata" to the json string. This v0.1 standard allows keys with any typical json values (numbers and strings) and one special value for the key "recording_start_time" which is saved to iso string format and loaded as a localized datetime.datetime object.

The maximum size of the metadata dictionary seems to be about 65 20-character strings or 160 integers. Trying to save more will result in fallback to default soundfile metadata. Soundfile doesn't give any complaint though, so this is a silent error.

The api for Audio has changed: .from_file boolean argument "metadata" is now "load_metadata" and .save() allows the user to choose "metadata_format" ("soundfile" reproduces previous behavior, "opso" chooses newest opso_metadata format, or user can specify exact format as "opso_metadata_v0.1"

I still use soundfile to update file metadata.

I have updated audio methods .trim(), .loop() and .extend() to update the relevant metadata - for instance, trim() will update "recording_start_time" to reflect the start time of the new audio object.

I have added tests to cover the new scenarios.