### PR TITLE
Change default args from lists to tuple

### DIFF
--- a/opensoundscape/audio.py
+++ b/opensoundscape/audio.py
@@ -587,7 +587,7 @@ class Audio:
             metadata=self.metadata,
         )
 
-    def apply_gain(self, dB, clip_range=[-1, 1]):
+    def apply_gain(self, dB, clip_range=(-1, 1)):
         """apply dB (decibels) of gain to audio signal
 
         Specifically, multiplies samples by 10^(dB/20)
@@ -924,7 +924,7 @@ def mix(
     gain=-3,
     offsets=None,
     sample_rate=None,
-    clip_range=[-1, 1],
+    clip_range=(-1, 1),
 ):
     """mixdown (superimpose) Audio signals into a single Audio object
 
@@ -957,7 +957,7 @@ def mix(
         clip_range: minimum and maximum sample values. Samples outside
             this range will be replaced by the range limit values
             Pass None to keep sample values without clipping.
-            [default: [-1,1]]
+            [default: (-1,1)]
 
 
     Returns:

--- a/opensoundscape/preprocess/actions.py
+++ b/opensoundscape/preprocess/actions.py
@@ -76,7 +76,7 @@ class Action(BaseAction):
     Other arguments are an arbitrary list of kwargs.
     """
 
-    def __init__(self, fn, is_augmentation=False, extra_args=[], **kwargs):
+    def __init__(self, fn, is_augmentation=False, extra_args=(), **kwargs):
         super(Action, self).__init__()
 
         self.action_fn = fn
@@ -163,7 +163,7 @@ class AudioTrim(Action):
 
     def __init__(self, **kwargs):
         super(AudioTrim, self).__init__(
-            trim_audio, extra_args=["_sample_duration"], **kwargs
+            trim_audio, extra_args=("_sample_duration",), **kwargs
         )
 
 
@@ -447,7 +447,7 @@ class Overlay(Action):
         super(Overlay, self).__init__(
             overlay,
             is_augmentation=is_augmentation,
-            extra_args=["_labels", "_preprocessor"],
+            extra_args=("_labels", "_preprocessor"),
             **kwargs,
         )
 

--- a/opensoundscape/preprocess/preprocessors.py
+++ b/opensoundscape/preprocess/preprocessors.py
@@ -214,10 +214,10 @@ class SpectrogramPreprocessor(BasePreprocessor):
         overlay_df: if not None, will include an overlay action drawing
             samples from this df
         out_shape:
-            output shape of tensor h,w,channels [default: [224,224,3]]
+            output shape of tensor h,w,channels [default: (224,224,3)]
     """
 
-    def __init__(self, sample_duration, overlay_df=None, out_shape=[224, 224, 3]):
+    def __init__(self, sample_duration, overlay_df=None, out_shape=(224, 224, 3)):
 
         super(SpectrogramPreprocessor, self).__init__(sample_duration=sample_duration)
 

--- a/opensoundscape/signal_processing.py
+++ b/opensoundscape/signal_processing.py
@@ -122,12 +122,12 @@ def cwt_peaks(
 
 def find_accel_sequences(
     t,
-    dt_range=[0.05, 0.8],
-    dy_range=[-0.2, 0],
-    d2y_range=[-0.05, 0.15],
+    dt_range=(0.05, 0.8),
+    dy_range=(-0.2, 0),
+    d2y_range=(-0.05, 0.15),
     max_skip=3,
-    duration_range=[1, 15],
-    points_range=[5, 100],
+    duration_range=(1, 15),
+    points_range=(5, 100),
 ):
     """
     detect accelerating/decelerating sequences in time series
@@ -159,15 +159,15 @@ def find_accel_sequences(
 
     Args:
         t: (list or np.array) times of all detected peaks (seconds)
-        dt_range=[0.05,0.8]: valid values for t(i) - t(i-1)
-        dy_range=[-0.2,0]: valid values for change in y
+        dt_range=(0.05,0.8): valid values for t(i) - t(i-1)
+        dy_range=(-0.2,0): valid values for change in y
             (grouse: difference in time between consecutive beats should decrease)
-        d2y_range=[-.05,.15]: limit change in dy: should not show large decrease
+        d2y_range=(-.05,.15): limit change in dy: should not show large decrease
             (sharp curve downward on y vs t plot)
         max_skip=3: max invalid points between valid points for a sequence
             (grouse: should not have many noisy points between beats)
-        duration_range=[1,15]: total duration of sequence (sec)
-        points_range=[9,100]: total number of points in sequence
+        duration_range=(1,15): total duration of sequence (sec)
+        points_range=(9,100): total number of points in sequence
 
     Returns:
         sequences_t, sequences_y: lists of t and y for each detected sequence
@@ -278,12 +278,12 @@ def detect_peak_sequence_cwt(
     wavelet="morl",
     peak_threshold=0.2,
     peak_separation=15 / 400,
-    dt_range=[0.05, 0.8],
-    dy_range=[-0.2, 0],
-    d2y_range=[-0.05, 0.15],
+    dt_range=(0.05, 0.8),
+    dy_range=(-0.2, 0),
+    d2y_range=(-0.05, 0.15),
     max_skip=3,
-    duration_range=[1, 15],
-    points_range=[9, 100],
+    duration_range=(1, 15),
+    points_range=(9, 100),
     plot=False,
 ):
     """Use a continuous wavelet transform to detect accellerating sequences
@@ -304,13 +304,13 @@ def detect_peak_sequence_cwt(
         wavelet='morl': (str) pywt wavelet name (see pywavelets docs)
         peak_threshold=0.2: height threhsold (0-1) for peaks in normalized signal
         peak_separation=15/400: min separation (sec) for peak finding
-        dt_range=[0.05, 0.8]: sequence detection point-to-point criterion 1
+        dt_range=(0.05, 0.8): sequence detection point-to-point criterion 1
             - Note: the upper limit is also used as sequence termination criterion 2
-        dy_range=[-0.2, 0]: sequence detection point-to-point criterion 2
-        d2y_range=[-0.05, 0.15]: sequence detection point-to-point criterion 3
+        dy_range=(-0.2, 0): sequence detection point-to-point criterion 2
+        d2y_range=(-0.05, 0.15): sequence detection point-to-point criterion 3
         max_skip=3: sequence termination criterion 1: max sequential invalid points
-        duration_range=[1, 15]: sequence criterion 1: length (sec) of sequence
-        points_range=[9, 100]: sequence criterion 2: num points in sequence
+        duration_range=(1, 15): sequence criterion 1: length (sec) of sequence
+        points_range=(9, 100): sequence criterion 2: num points in sequence
         plot=False: if True, plot peaks and detected sequences with pyplot
 
     Returns:

--- a/opensoundscape/torch/models/cnn.py
+++ b/opensoundscape/torch/models/cnn.py
@@ -65,6 +65,9 @@ class CNN(BaseModule):
             - True: model expects exactly one positive class per sample
             - False: samples can have any number of positive classes
             [default: False]
+        preprocessor_class: class of Preprocessor object
+        sample_shape: tuple of height, width, channels for created sample
+            [default: (224,224,3)]
 
     """
 
@@ -75,7 +78,7 @@ class CNN(BaseModule):
         sample_duration,
         single_target=False,
         preprocessor_class=SpectrogramPreprocessor,
-        sample_shape=[224, 224, 3],
+        sample_shape=(224, 224, 3),
     ):
 
         super(CNN, self).__init__()
@@ -1102,7 +1105,7 @@ class InceptionV3(CNN):
         preprocessor_class=SpectrogramPreprocessor,
         freeze_feature_extractor=False,
         use_pretrained=True,
-        sample_shape=[299, 299, 3],
+        sample_shape=(299, 299, 3),
     ):
         """Model object for InceptionV3 architecture subclassing CNN
 

--- a/opensoundscape/wandb.py
+++ b/opensoundscape/wandb.py
@@ -5,7 +5,7 @@ from opensoundscape.annotations import one_hot_to_categorical
 from opensoundscape.audio import Audio
 
 
-def wandb_table(dataset, n=None, classes_to_extract=[], random_state=None):
+def wandb_table(dataset, n=None, classes_to_extract=(), random_state=None):
     """Generate a wandb Table visualizing n random samples from a sample_df
 
     Args:
@@ -13,7 +13,7 @@ def wandb_table(dataset, n=None, classes_to_extract=[], random_state=None):
         n: number of samples to generate (randomly selected from df)
             - if None, does not subsample or change order
         bypass_augmentations: if True, augmentations in Preprocessor are skipped
-        classes_to_extract: list of classes - will create columns containing the scores/labels
+        classes_to_extract: tuple of classes - will create columns containing the scores/labels
         random_state: default None; if integer provided, used for reproducible random sample
 
     Returns: a W&B Table of preprocessed samples with labels and playable audio
@@ -33,7 +33,7 @@ def wandb_table(dataset, n=None, classes_to_extract=[], random_state=None):
         table_columns += ["clip start time"]
         table_columns += ["clip end time"]
     for c in classes_to_extract:
-        table_columns += classes_to_extract
+        table_columns += c
 
     classes = dataset.label_df.columns
 


### PR DESCRIPTION
Default arg as a (mutable) list can cause unexpected/surprising behavior because the list is only initialized once and can be modified. I've changed any default arguments that were lists to tuples. Behavior is the same, but note that a 1-element tuple must be written with a comma, eg (0,) because (0) is not interpreted as a tuple

resolves #643 