### PR TITLE
Issue 562 preprocessing raise errors

### DIFF
--- a/opensoundscape/torch/models/cnn.py
+++ b/opensoundscape/torch/models/cnn.py
@@ -882,7 +882,7 @@ class CNN(BaseModule):
             )
             return pd.DataFrame(columns=self.classes)
 
-        # SafeDataset will not fail on bad files,
+        # If unsafe_behavior= "substitute", a SafeDataset will not fail on bad files,
         # but will provide a different sample! Later we go back and replace scores
         # with np.nan for the bad samples (using safe_dataset._unsafe_indices)
         # this approach to error handling feels hacky

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -386,3 +386,17 @@ def test_train_no_validation(train_df):
     model = cnn.CNN("resnet18", classes=[0, 1], sample_duration=2)
     model.train(train_df, save_path="tests/models")
     shutil.rmtree("tests/models/")
+
+
+def test_train_raise_errors(missing_file_df):
+    # test that model.train raises errors if raise_errors=True
+    model = cnn.CNN("resnet18", classes=[0, 1], sample_duration=2)
+    with pytest.raises(ValueError):
+        model.train(missing_file_df, raise_errors=True)
+
+
+def test_predict_raise_errors(missing_file_df):
+    # test that model.predict raises errors if raise_errors=True
+    model = cnn.CNN("resnet18", classes=[0, 1], sample_duration=2)
+    with pytest.raises(ValueError):
+        model.predict(missing_file_df, raise_errors=True)


### PR DESCRIPTION
Resolves #562 by adding a `raise_errors` boolean argument to predict and train functions. If this argument is true, any underlying preprocessing error will be raised. This reduces potentially confusing situations where the `SafeDataset` object hides the fact that there has been a preprocessing error.