### PR TITLE
add missing mock-imports

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,6 +99,8 @@ autodoc_mock_imports = [
     "matplotlib",
     "pywt",
     "deprecated",
+    "skimage",
+    "wandb",
 ]
 
 master_doc = "index"


### PR DESCRIPTION
autodoc_mock_imports needed two additions, "skimage" and "wandb". The absence of these was causing empty documentation of all modules.