### PR TITLE
Implement wandb.watch in CNN.train()

### DIFF
--- a/opensoundscape/torch/models/cnn.py
+++ b/opensoundscape/torch/models/cnn.py
@@ -334,7 +334,7 @@ class CNN(BaseModule):
             ####################
 
             # forward pass: feature extractor and classifier
-            logits = self.network.forward(batch_tensors)
+            logits = self.network(batch_tensors)
 
             # save targets and predictions
             total_scores.append(logits.detach().cpu().numpy())
@@ -983,7 +983,7 @@ class CNN(BaseModule):
                 batch_tensors.requires_grad = False
 
                 # forward pass of network: feature extractor + classifier
-                logits = self.network.forward(batch_tensors)
+                logits = self.network(batch_tensors)
 
                 ### Activation layer ###
                 scores = apply_activation_layer(logits, activation_layer)
@@ -1211,7 +1211,7 @@ class InceptionV3(CNN):
 
             # forward pass: feature extractor and classifier
             # inception returns two sets of outputs
-            inception_outputs = self.network.forward(batch_tensors)
+            inception_outputs = self.network(batch_tensors)
             logits = inception_outputs.logits
             aux_logits = inception_outputs.aux_logits
 

--- a/opensoundscape/torch/models/cnn.py
+++ b/opensoundscape/torch/models/cnn.py
@@ -95,7 +95,7 @@ class CNN(BaseModule):
             n_preview_samples=8,  # before train/predict, log n random samples
             top_samples_classes=None,  # specify list of classes to see top samples from
             n_top_samples=3,  # after prediction, log n top scoring samples per class
-            # logs histograms of params & grads every n steps;
+            # logs histograms of params & grads every n batches;
             watch_freq=10,  # use  None for no logging of params & grads
         )
         self.loss_fn = None

--- a/opensoundscape/torch/models/cnn.py
+++ b/opensoundscape/torch/models/cnn.py
@@ -95,6 +95,8 @@ class CNN(BaseModule):
             n_preview_samples=8,  # before train/predict, log n random samples
             top_samples_classes=None,  # specify list of classes to see top samples from
             n_top_samples=3,  # after prediction, log n top scoring samples per class
+            # logs histograms of params & grads every n steps;
+            watch_freq=10,  # use  None for no logging of params & grads
         )
         self.loss_fn = None
         self.train_loader = None
@@ -554,13 +556,13 @@ class CNN(BaseModule):
             # log tables of preprocessed samples
             wandb_session.log(
                 {
-                    "Samples / training samples w/augmentation": opensoundscape.wandb.wandb_table(
+                    "Samples / training samples": opensoundscape.wandb.wandb_table(
                         AudioFileDataset(
                             train_df, self.preprocessor, bypass_augmentations=False
                         ),
                         self.wandb_logging["n_preview_samples"],
                     ),
-                    "Samples / training samples w/o augmentation": opensoundscape.wandb.wandb_table(
+                    "Samples / training samples no aug": opensoundscape.wandb.wandb_table(
                         AudioFileDataset(
                             train_df, self.preprocessor, bypass_augmentations=True
                         ),
@@ -1175,6 +1177,16 @@ class InceptionV3(CNN):
         total_scores = []
         batch_loss = []
 
+        # use wandb.watch to log histograms of parameter and gradient values
+        # value of None for log_freq means do not use wandb.watch()
+        log_freq = self.wandb_logging["watch_freq"]
+        if log_freq is not None:
+            wandb_session.watch(
+                self.network, log="all", log_freq=log_freq, log_graph=(True)
+            )
+        # we use watch and unwatch within this function because leaving the model watched
+        # is undesirable (eg, cannot pickle model object)
+
         for batch_idx, batch_data in enumerate(train_loader):
             # load a batch of images and labels from the train loader
             # all augmentation occurs in the Preprocessor (train_loader)
@@ -1259,6 +1271,8 @@ class InceptionV3(CNN):
         total_tgts = np.concatenate(total_tgts, axis=0)
         total_preds = np.concatenate(total_preds, axis=0)
         total_scores = np.concatenate(total_scores, axis=0)
+
+        wandb_session.unwatch(self.network)
 
         return total_tgts, total_preds, total_scores
 


### PR DESCRIPTION
the .watch() functionality of wandb allows the user to see distributions of weights and gradients of each layer, and also provides an overall network topology view. This branch turns on this wandb feature by default in CNN.train when using wandb logging (when user passes a wandb session to the wandb_session argument)

This branch also changes forward calls of PyTorch modules from m.forward() to m(). This is the proper syntax, and forward hooks are skipped if the forward() method is used instead. 