### PR TITLE
implement save_torch_dict and load_torch_dict

### DIFF
--- a/opensoundscape/preprocess/actions.py
+++ b/opensoundscape/preprocess/actions.py
@@ -224,6 +224,20 @@ def trim_audio(sample, extend=True, random_trim=False, tol=1e-5):
     return sample
 
 
+class SpectrogramToTensor(BaseAction):
+    """Action to create Tesnsor of desired shape from Spectrogram"""
+
+    def go(self, sample, **kwargs):
+        """converts sample.data from Spectrogram to Tensor"""
+        # sample.data must be Spectrogram object
+        # sample should have attribute target_shape [h,w,channels]
+        sample.data = sample.data.to_image(
+            shape=sample.target_shape[0:2],
+            channels=sample.target_shape[2],
+            return_type="torch",
+        )
+
+
 def audio_random_gain(audio, dB_range=(-30, 0), clip_range=(-1, 1)):
     """Applies a randomly selected gain level to an Audio object
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -10,6 +10,7 @@ from opensoundscape.preprocess import actions
 from opensoundscape.sample import AudioSample
 from PIL import Image
 import torch
+from opensoundscape.spectrogram import Spectrogram
 
 ## Fixtures: prepare objects that can be used by tests ##
 
@@ -143,6 +144,15 @@ def test_audio_add_noise(sample_audio):
         actions.audio_add_noise, noise_dB=-100, signal_dB=10, color="pink"
     )
     action.go(sample_audio)
+
+
+def test_spectrogram_to_tensor(sample, sample_audio):
+    action = actions.SpectrogramToTensor()
+    sample.data = Spectrogram.from_audio(sample_audio.data)
+    sample.target_shape = [20, 30, 3]  # note channels as dim2
+    action.go(sample)  # converts .data from Spectrogram to Tensor
+    assert isinstance(sample.data, torch.Tensor)
+    assert list(sample.data.shape) == [3, 20, 30]  # note channels as dim0
 
 
 def test_color_jitter(tensor):

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -322,6 +322,23 @@ def test_save_and_load_model(model_save_path):
     assert type(m) == cnn.InceptionV3
 
 
+def test_save_and_load_torch_dict(model_save_path):
+    arch = alexnet(2, weights=None)
+    classes = [0, 1]
+    with pytest.warns(UserWarning):
+        # warns user bc can't recreate custom architecture
+        cnn.CNN(arch, classes, 1.0).save_torch_dict(model_save_path)
+        # can do model.architecture_name='alexnet' to enable reloading
+
+    # works when arch is string
+    cnn.CNN("resnet18", classes, 1.0).save_torch_dict(model_save_path)
+    m = cnn.CNN.from_torch_dict(model_save_path)
+    assert m.classes == classes
+    assert type(m) == cnn.CNN
+
+    # not implemented for InceptionV3 (from_torch_dict raises NotImplementedError)
+
+
 def test_save_load_and_train_model_resample_loss(train_df):
     arch = alexnet(2, weights=None)
     classes = [0, 1]


### PR DESCRIPTION
these functions save and load a dictionary of basic model structure and weights, an alternative to .save() which pickles the entire object and will break across opensoundscape versions