### PR TITLE
Issue 679 retain metadata when using Audio methods

### DIFF
--- a/opensoundscape/audio.py
+++ b/opensoundscape/audio.py
@@ -105,6 +105,10 @@ class Audio:
 
         pass any desired updates as kwargs
         """
+        assert np.all(k in self.__slots__ for k in kwargs.keys()), (
+            "only pass members of Audio.__slots__ to _spawn as kwargs! "
+            f"slots: {self.__slots__}"
+        )
         # load the current values from each __slots__ key
         slots = {key: self.__getattribute__(key) for key in self.__slots__}
         # update any user-specified values

--- a/opensoundscape/audio.py
+++ b/opensoundscape/audio.py
@@ -105,7 +105,7 @@ class Audio:
 
         pass any desired updates as kwargs
         """
-        assert np.all(k in self.__slots__ for k in kwargs.keys()), (
+        assert np.all([k in self.__slots__ for k in kwargs.keys()]), (
             "only pass members of Audio.__slots__ to _spawn as kwargs! "
             f"slots: {self.__slots__}"
         )

--- a/opensoundscape/audio.py
+++ b/opensoundscape/audio.py
@@ -100,6 +100,18 @@ class Audio:
         if samples_error:
             raise ValueError(f"Audio initialization failed with:\n{samples_error}")
 
+    def _spawn(self, **kwargs):
+        """return copy of object, replacing any desired fields from __slots__
+
+        pass any desired updates as kwargs
+        """
+        # load the current values from each __slots__ key
+        slots = {key: self.__getattribute__(key) for key in self.__slots__}
+        # update any user-specified values
+        slots.update(kwargs)
+        # create new instance of the class
+        return self.__class__(**slots)
+
     @classmethod
     def silence(cls, duration, sample_rate):
         """ "Create audio object with zero-valued samples
@@ -390,7 +402,11 @@ class Audio:
             res_type=resample_type,
         )
 
-        return Audio(samples_resampled, sample_rate, resample_type=resample_type)
+        return self._spawn(
+            samples=samples_resampled,
+            sample_rate=sample_rate,
+            resample_type=resample_type,
+        )
 
     def trim(self, start_time, end_time):
         """Trim Audio object in time
@@ -420,10 +436,8 @@ class Audio:
             if "duration" in metadata:
                 metadata["duration"] = len(samples_trimmed) / self.sample_rate
 
-        return Audio(
-            samples_trimmed,
-            self.sample_rate,
-            resample_type=self.resample_type,
+        return self._spawn(
+            samples=samples_trimmed,
             metadata=metadata,
         )
 
@@ -461,10 +475,8 @@ class Audio:
             if "duration" in metadata:
                 metadata["duration"] = len(samples_extended) / self.sample_rate
 
-        return Audio(
-            samples_extended,
-            self.sample_rate,
-            resample_type=self.resample_type,
+        return self._spawn(
+            samples=samples_extended,
             metadata=metadata,
         )
 
@@ -491,10 +503,8 @@ class Audio:
             if "duration" in metadata:
                 metadata["duration"] = len(samples_extended) / self.sample_rate
 
-        return Audio(
-            samples_extended,
-            self.sample_rate,
-            resample_type=self.resample_type,
+        return self._spawn(
+            samples=samples_extended,
             metadata=metadata,
         )
 
@@ -519,9 +529,7 @@ class Audio:
         filtered_samples = bandpass_filter(
             self.samples, low_f, high_f, self.sample_rate, order=order
         )
-        return Audio(
-            filtered_samples, self.sample_rate, resample_type=self.resample_type
-        )
+        return self._spawn(samples=filtered_samples)
 
     def spectrum(self):
         """Create frequency spectrum from an Audio object using fft
@@ -584,12 +592,7 @@ class Audio:
             # don't try to normalize 0-valued samples. Return original object
             abs_max = 1
 
-        return Audio(
-            self.samples / abs_max * peak_level,
-            self.sample_rate,
-            resample_type=self.resample_type,
-            metadata=self.metadata,
-        )
+        return self._spawn(samples=self.samples / abs_max * peak_level)
 
     def apply_gain(self, dB, clip_range=(-1, 1)):
         """apply dB (decibels) of gain to audio signal
@@ -609,12 +612,7 @@ class Audio:
         samples = self.samples * (10 ** (dB / 20))
         if clip_range is not None:
             samples = np.clip(samples, clip_range[0], clip_range[1])
-        return Audio(
-            samples,
-            self.sample_rate,
-            resample_type=self.resample_type,
-            metadata=self.metadata,
-        )
+        return self._spawn(samples=samples)
 
     def save(
         self,
@@ -915,10 +913,9 @@ def concat(audio_objects, sample_rate=None):
         sample_rate = audio_objects[0].sample_rate
 
     # concatenate sample arrays to form new Audio object
-    return Audio(
-        np.hstack([a.resample(sample_rate).samples for a in audio_objects]),
-        sample_rate,
-        resample_type=audio_objects[0].resample_type,
+    return audio_objects[0]._spawn(
+        samples=np.hstack([a.resample(sample_rate).samples for a in audio_objects]),
+        sample_rate=sample_rate,
     )
 
 
@@ -1045,7 +1042,7 @@ def mix(
     if clip_range is not None:
         mixdown = np.clip(mixdown, clip_range[0], clip_range[1])
 
-    return Audio(mixdown, sample_rate, resample_type=audio_objects[0].resample_type)
+    return audio_objects[0]._spawn(samples=mixdown, sample_rate=sample_rate)
 
 
 def parse_opso_metadata(comment_string):

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -393,6 +393,22 @@ def test_resample_veryshort_wav(veryshort_wav_str):
     assert resampled_audio.sample_rate == 22050
 
 
+def test_methods_retain_metadata(metadata_wav_str):
+    """resolved issue 679 by implementing ._spawn
+    This should avoid future issues with improperly calling
+    Audio.__init__ ie if the arguments to __init__ change
+    """
+    audio = Audio.from_file(metadata_wav_str)
+    a2 = audio.resample(22050)
+    assert audio.metadata == a2.metadata
+
+    a2 = audio.apply_gain(-2)
+    assert audio.metadata == a2.metadata
+
+    a2 = audio.normalize()
+    assert audio.metadata == a2.metadata
+
+
 def test_resample_mp3_nonstandard_sr(silence_10s_mp3_str):
     audio = Audio.from_file(silence_10s_mp3_str, sample_rate=10000)
     dur = audio.duration

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -393,6 +393,22 @@ def test_resample_veryshort_wav(veryshort_wav_str):
     assert resampled_audio.sample_rate == 22050
 
 
+def test_spawn(veryshort_wav_audio):
+    """spawn method creates copy of Audio object with any kwarg fields updated"""
+    a = veryshort_wav_audio
+    a2 = a._spawn()
+    assert np.all(a2.samples == a.samples)
+    assert a2.sample_rate == a.sample_rate
+
+    # provide an updated value for the new object
+    a3 = a._spawn(sample_rate=20)
+    assert a3.sample_rate == 20
+
+    with pytest.raises(AssertionError):
+        # should not be able to pass non __slot__ kwargs
+        a._spawn(b=1)
+
+
 def test_methods_retain_metadata(metadata_wav_str):
     """resolved issue 679 by implementing ._spawn
     This should avoid future issues with improperly calling


### PR DESCRIPTION
## implement Audio._spawn
resolves Some Audio functions erase Audio object metadata https://github.com/kitzeslab/opensoundscape/issues/679

instead of calling Audio() with all kwargs every time we need to make a new audio object in an out-of-place Audio method, we now call self._spawn() which uses all of the current object's parameters by default and only updates things passed as kwargs to _spawn(). This should avoid issues like https://github.com/kitzeslab/opensoundscape/issues/679 where unspecified init arguments result in loss of info in out-of-place operations