### PR TITLE
add gcc (generalized cross correlation) function and tests

### DIFF
--- a/opensoundscape/audio.py
+++ b/opensoundscape/audio.py
@@ -1109,7 +1109,12 @@ def mix(
 
 
 def estimate_delay(
-    audio, reference_audio, bandpass_range=None, bandpass_order=9, cc_filter="phat"
+    audio,
+    reference_audio,
+    bandpass_range=None,
+    bandpass_order=9,
+    cc_filter="phat",
+    return_cc_max=False,
 ):
     """Use generalized cross correlation to estimate time delay between signals
 
@@ -1125,8 +1130,13 @@ def estimate_delay(
         bandpass_order: order of Butterworth bandpass filter
         cc_filter: generalized cross correlation type, see
             opensoundscape.signal_processing.gcc() [default: 'phat']
+        return_cc_max: if True, returns cross correlation max value as second argument
+            (see opensoundscape.signal_processing.tdoa)
     Returns:
         estimated time delay (seconds) from reference_audio to audio
+
+        if return_cc_max is True, returns second value, the max of the cross correlation
+        of the two signals
 
     Note: resamples reference_audio if its sample rate does not match audio
     """
@@ -1143,7 +1153,11 @@ def estimate_delay(
 
     # estimate time delay from reference_audio to audio using generalized cross correlation
     return tdoa(
-        audio.samples, reference_audio.samples, cc_filter=cc_filter, sample_rate=sr
+        audio.samples,
+        reference_audio.samples,
+        cc_filter=cc_filter,
+        sample_rate=sr,
+        return_max=return_cc_max,
     )
 
 

--- a/opensoundscape/audio.py
+++ b/opensoundscape/audio.py
@@ -1107,34 +1107,38 @@ def mix(
 
     return audio_objects[0]._spawn(samples=mixdown, sample_rate=sample_rate)
 
-def estimate_delay(audio1,audio2,bandpass_range=None,bandpass_order=9,cc_filter='phat'):
+
+def estimate_delay(
+    audio1, audio2, bandpass_range=None, bandpass_order=9, cc_filter="phat"
+):
     """Use generalized cross correlation to estimate time delay between signals
-    
+
     optionally bandpass to a frequency range
-    
+
     Args:
         audio1, audio2: audio objects
         bandpass_range: if None, no bandpass filter is performed
             otherwise [low_f,high_f]
         bandpass_order: order of Butterworth bandpass filter
-        cc_filter: generalized cross correlation type, see 
+        cc_filter: generalized cross correlation type, see
             opensoundscape.signal_processing.gcc() [default: 'phat']
     Returns:
-        estimated time delay (seconds) 
+        estimated time delay (seconds)
         if audio2 is delayed by 1 second compared to audio1, result is -1.0
 
     Note: resamples audio2 if its sample rate does not match audio1
     """
     # sample rates must match
     sr = audio1.sample_rate
-    if audio2.sample_rate != sr
+    if audio2.sample_rate != sr:
         audio2 = audio2.resample(sr)
-    
-    if bandpass_range is not None:
-        audio1=audio1.bandpass(bandpass_range[0],bandpass_range[1],bandpass_order)
-        audio2=audio2.bandpass(bandpass_range[0],bandpass_range[1],bandpass_order)
 
-    return tdoa(audio1.samples,audio2.samples,cc_filter=cc_filter,sample_rate=sr)
+    if bandpass_range is not None:
+        audio1 = audio1.bandpass(bandpass_range[0], bandpass_range[1], bandpass_order)
+        audio2 = audio2.bandpass(bandpass_range[0], bandpass_range[1], bandpass_order)
+
+    return tdoa(audio1.samples, audio2.samples, cc_filter=cc_filter, sample_rate=sr)
+
 
 def parse_opso_metadata(comment_string):
     """parse metadata saved by opensoundcsape as json in comment field

--- a/opensoundscape/audio.py
+++ b/opensoundscape/audio.py
@@ -35,6 +35,7 @@ import IPython.display
 import opensoundscape
 from opensoundscape.utils import generate_clip_times_df, load_metadata
 from opensoundscape.aru import parse_audiomoth_metadata
+from opensoundscape.signal_processing import tdoa
 from scipy.signal import butter, sosfiltfilt
 
 DEFAULT_RESAMPLE_TYPE = "soxr_hq"  # changed from kaiser_fast in v0.9.0
@@ -1106,6 +1107,34 @@ def mix(
 
     return audio_objects[0]._spawn(samples=mixdown, sample_rate=sample_rate)
 
+def estimate_delay(audio1,audio2,bandpass_range=None,bandpass_order=9,cc_filter='phat'):
+    """Use generalized cross correlation to estimate time delay between signals
+    
+    optionally bandpass to a frequency range
+    
+    Args:
+        audio1, audio2: audio objects
+        bandpass_range: if None, no bandpass filter is performed
+            otherwise [low_f,high_f]
+        bandpass_order: order of Butterworth bandpass filter
+        cc_filter: generalized cross correlation type, see 
+            opensoundscape.signal_processing.gcc() [default: 'phat']
+    Returns:
+        estimated time delay (seconds) 
+        if audio2 is delayed by 1 second compared to audio1, result is -1.0
+
+    Note: resamples audio2 if its sample rate does not match audio1
+    """
+    # sample rates must match
+    sr = audio1.sample_rate
+    if audio2.sample_rate != sr
+        audio2 = audio2.resample(sr)
+    
+    if bandpass_range is not None:
+        audio1=audio1.bandpass(bandpass_range[0],bandpass_range[1],bandpass_order)
+        audio2=audio2.bandpass(bandpass_range[0],bandpass_range[1],bandpass_order)
+
+    return tdoa(audio1.samples,audio2.samples,cc_filter=cc_filter,sample_rate=sr)
 
 def parse_opso_metadata(comment_string):
     """parse metadata saved by opensoundcsape as json in comment field

--- a/opensoundscape/signal_processing.py
+++ b/opensoundscape/signal_processing.py
@@ -497,7 +497,7 @@ def gcc(x, y, cc_filter="phat", epsilon=0.001):
         phi = 1 / (np.abs(Gxy) + epsilon)
 
     elif cc_filter == "roth":
-        phi = 1 / (X * torch.conj(X) + epsilon)
+        phi = 1 / (X * np.conj(X) + epsilon)
 
     elif cc_filter == "scot":
         Gxx = X * np.conj(X)
@@ -518,19 +518,8 @@ def gcc(x, y, cc_filter="phat", epsilon=0.001):
     # Inverse FFT to get the GCC
     cc = np.fft.irfft(Gxy * phi, n)
 
+    # reorder the cross-correlation coefficients, trimming out padded regions
+    # order of outputs matches np.correlate and scipy.signal.correlate
+    cc = np.concatenate((cc[-y.shape[0] + 1 :], cc[: x.shape[0]]))
+
     return cc
-
-
-def correlation_lags(correlation_length):
-    """Get time-delays (lags) in samples for the output of a correlation function
-    Args:
-        correlation_length: length of cross-correlation output
-    Returns:
-        lags: np.array of corresponding lags
-    """
-    middle = correlation_length // 2
-    right_max = middle + 1 if correlation_length % 2 else middle
-    left_half = np.arange(0, middle, 1)
-    right_half = np.arange(-right_max, 0, 1)
-    lags = np.concatenate([left_half, right_half])
-    return lags

--- a/opensoundscape/signal_processing.py
+++ b/opensoundscape/signal_processing.py
@@ -507,7 +507,7 @@ def gcc(x, y, cc_filter="phat", epsilon=0.001, radius=None):
         n += 1
     # by choosing an optimal length rather than the shortest possible, we can
     # optimize fft speed
-    n_fast = n  # next_fast_len(n, real=True)
+    n_fast = next_fast_len(n, real=True)
 
     # Take the reall Fast Fourier Transform of the signals
     X = torch.fft.rfft(x, n=n_fast)

--- a/opensoundscape/signal_processing.py
+++ b/opensoundscape/signal_processing.py
@@ -501,13 +501,14 @@ def gcc(x, y, cc_filter="phat", epsilon=0.001):
     elif cc_filter == "scot":
         Gxx = X * np.conj(X)
         Gyy = Y * np.conj(Y)
-        phi = 1 / (np.sqrt(X * Y) + epsilon)
+        phi = 1 / (np.sqrt(Gxx * Gyy) + epsilon)
 
     elif cc_filter == "ht":
         Gxx = X * np.conj(X)
         Gyy = Y * np.conj(Y)
         gamma = Gxy / np.sqrt(Gxx * Gxy)
-        phi = np.abs(gamma) ** 2 / (np.abs(Gxy) * (1 - gamma) ** 2 + epsilon)
+        coherence = np.abs(gamma) ** 2
+        phi = coherence / (np.abs(Gxy) * coherence + epsilon)
     elif cc_filter == "cc":
         phi = 1.0
     else:

--- a/opensoundscape/signal_processing.py
+++ b/opensoundscape/signal_processing.py
@@ -527,9 +527,9 @@ def gcc(x, y, cc_filter="phat", epsilon=0.001, radius=None):
     elif cc_filter == "ht":
         Gxx = X * torch.conj(X)
         Gyy = Y * torch.conj(Y)
-        gamma = Gxy / torch.sqrt(Gxx * Gxy)
+        gamma = Gxy / torch.sqrt(Gxx * Gyy)
         coherence = torch.abs(gamma) ** 2
-        phi = coherence / (torch.abs(Gxy) * coherence + epsilon)
+        phi = coherence / (torch.abs(Gxy) * (1 - coherence) + epsilon)
     elif cc_filter == "cc":
         phi = 1.0
     else:

--- a/opensoundscape/signal_processing.py
+++ b/opensoundscape/signal_processing.py
@@ -480,12 +480,11 @@ def gcc(x, y, cc_filter="phat", epsilon=0.001):
     The Generalized Correlation Method for Estimation of Time Delay. IEEE Trans. Acoust. Speech Signal Process, 24, 320-327.
     http://dx.doi.org/10.1109/TASSP.1976.1162830
     """
-    n = x.shape[0] + y.shape[0]
 
-    # Zero pad the signals. This is necessary because convolutions are
-    # circular, and 'wrap around' the end of the signal. Zero padding avoids this
-    x = np.pad(x, (0, n - x.shape[0]), "constant")
-    y = np.pad(y, (0, n - y.shape[0]), "constant")
+    # padd the fft for "full" cross correlation of both signals
+    n = x.shape[0] + y.shape[0] - 1
+    if n % 2 != 0:
+        n += 1
 
     # Take the FFT of the signals and multiply 1 by the complex conjugate of the other
     X = np.fft.rfft(x, n=n)

--- a/opensoundscape/signal_processing.py
+++ b/opensoundscape/signal_processing.py
@@ -527,8 +527,8 @@ def gcc(x, y, cc_filter="phat", epsilon=0.001, radius=None):
     elif cc_filter == "ht":
         Gxx = X * torch.conj(X)
         Gyy = Y * torch.conj(Y)
-        gamma = Gxy / torch.sqrt(Gxx * Gyy)
-        coherence = torch.abs(gamma) ** 2
+        gamma_xy = Gxy / (torch.sqrt(Gxx * Gyy) + epsilon)
+        coherence = torch.abs(gamma_xy) ** 2
         phi = coherence / (torch.abs(Gxy) * (1 - coherence) + epsilon)
     elif cc_filter == "cc":
         phi = 1.0

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -718,3 +718,10 @@ def test_estimate_delay_with_bandpass(veryshort_audio):
         sig, veryshort_audio, bandpass_range=[1000, 3000], bandpass_order=5
     )
     assert isclose(dly, 0.1, abs_tol=1e-6)
+
+
+def test_estimate_delay_return_cc_max(veryshort_audio):
+    a = veryshort_audio
+    t, ccmax = audio.estimate_delay(a, a, return_cc_max=True, cc_filter="cc")
+    assert isclose(ccmax, sum(a.samples * a.samples), abs_tol=1e-5)
+    assert isclose(t, 0, abs_tol=1e-6)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -698,3 +698,23 @@ def test_bandpass_filter(veryshort_audio):
 
 def test_clipping_detector(veryshort_audio):
     assert audio.clipping_detector(veryshort_audio.samples) > -1
+
+
+def test_estimate_delay(veryshort_audio):
+    # shift signal backward
+    sig = audio.concat(
+        [Audio.silence(0.1, veryshort_audio.sample_rate), veryshort_audio]
+    )
+
+    assert isclose(audio.estimate_delay(sig, veryshort_audio), 0.1, abs_tol=1e-6)
+
+
+def test_estimate_delay_with_bandpass(veryshort_audio):
+    # shift signal backward
+    sig = audio.concat(
+        [Audio.silence(0.1, veryshort_audio.sample_rate), veryshort_audio]
+    )
+    dly = audio.estimate_delay(
+        sig, veryshort_audio, bandpass_range=[1000, 3000], bandpass_order=5
+    )
+    assert isclose(dly, 0.1, abs_tol=1e-6)

--- a/tests/test_signal_processing.py
+++ b/tests/test_signal_processing.py
@@ -4,6 +4,7 @@ import pytest
 import numpy as np
 from opensoundscape import signal_processing as sp
 from numpy.testing import assert_allclose
+from math import isclose
 
 
 @pytest.fixture()
@@ -276,3 +277,19 @@ def test_cc_scipy_equivalence():
         gccs = sp.gcc(a, b, cc_filter="cc")  # use plain cross-correlation
         # should be exactly the same as scipy.signal.correlate
         assert_allclose(gccs, sig.correlate(a, b, mode="full"), 1e-6, 1)
+
+
+def test_tdoa_return_max():
+    # option to return max of cc as well as estimated time delay
+    delay = 20  # samples of delay (positive: second signal arrives before first)
+    start = 500  # start of signal
+    end = 510  # end of signal
+
+    a = np.zeros(1000)
+    a[start:end] = 3  # impulse
+    b = np.zeros(1000)
+    b[start - delay : end - delay] = 3
+
+    # filter methods will change the output values of cc, but plain cc gives expected value
+    delay, cc_max = sp.tdoa(a, b, cc_filter="cc", sample_rate=1, return_max=True)
+    assert isclose(cc_max, 3 * 3 * (end - start), abs_tol=1e-4)

--- a/tests/test_signal_processing.py
+++ b/tests/test_signal_processing.py
@@ -210,3 +210,53 @@ def test_thresholded_event_durations():
     )
     assert np.array_equal(starts, np.array([0, 2]))
     assert np.array_equal(lengths, np.array([1, 1]))
+
+
+def test_gcc():
+    # test our gcc implementation with an easy case
+    np.random.seed(0)
+    delay = 200  # samples
+    start = 500  # start of signal
+    end = 510  # end of signal
+
+    a = np.zeros(1000)
+    a[start:end] = 3  # impulse
+    a += np.random.rand(1000)  # add noise
+    b = np.zeros(1000)
+    b[
+        start + delay : end + delay
+    ] = 3  # signal b is identical to a, but delayed by delay samples
+    b += np.random.rand(1000)  # add noise
+
+    for cc_filter in ["cc", "phat", "roth", "scot", "ht"]:
+        gccs = sp.gcc(a, b)
+        # assert that the argmax is the correct delay
+        expected_max_cc = gccs[-delay]
+        assert expected_max_cc == np.max(gccs)
+
+
+def test_gcc_against_scipy():
+    ## test our implementation of plain cross-correlation (no filter)
+    ## against scipy.signal.correlate, to ensure correctness
+    import scipy.signal as sig
+
+    for delay in range(-499, 489):
+
+        start = 500  # start of signal
+        end = 510  # end of signal
+
+        a = np.zeros(1000)
+        a[start:end] = 3  # impulse
+        a += np.random.rand(1000)  # add noise
+        b = np.zeros(1000)
+        b[start + delay : end + delay] = 3
+        b += np.random.rand(1000)
+        gccs = sp.gcc(a, b, cc_filter="cc")  # use plain cross-correlation
+        # assert that the argmax is the correct delay
+        opso_lags = sp.correlation_lags(len(gccs))
+        opso_delay = opso_lags[np.argmax(gccs)]
+
+        scipy_lags = sig.correlation_lags(len(a), len(b), mode="full")
+        scipy_delay = scipy_lags[np.argmax(sig.correlate(a, b, mode="full"))]
+
+        assert opso_delay == scipy_delay


### PR DESCRIPTION
This PR adds an implementation of generalized cross correlation. There are some things that should be changed - either before in PR or in a later release.
- The correlation_lags function outputs the lag corresponding to each cross-correlation value in the output of gcc. Our correlation_lags are different so scipy.signal.correlation_lags, because the elements of their cross-correlation function are in a different order. We should instead standardize our output of gcc, so that the order of the elements matches the order of lags used by scipy.signal.correlation_lags. This may just require reversing one of the signals before convolution. I just need to test this.
- Our gcc function is, slow. We should test if we can use scipy.signal.convolve in our implementation, and if it is any faster.
