### PR TITLE
Increase tolerance of Audio too short warning

### DIFF
--- a/opensoundscape/audio.py
+++ b/opensoundscape/audio.py
@@ -324,7 +324,7 @@ class Audio:
                 raise AudioOutOfBoundsError(error_msg)
             elif out_of_bounds_mode == "warn":
                 warnings.warn(error_msg)
-        elif duration is not None and len(samples) < duration * sr:
+        elif duration is not None and len(samples) < np.floor(duration * sr):
             if offset < 0:
                 error_msg = "requested time period begins before start of recording"
             else:


### PR DESCRIPTION
resolves #721

Before this, the 'Audio too short warning' was being raised due to a mistake in float/sample rounding.
I.e. if the expected length of the audio was 725.4 samples, but the audio object was 725 samples, because the
'expected duration' was calculated at subsample precision, we would raise a Warning.

This hopefully fixes that.

