### PR TITLE
metadata parsing resolve #745

### DIFF
--- a/opensoundscape/aru.py
+++ b/opensoundscape/aru.py
@@ -136,7 +136,8 @@ def _parse_audiomoth_comment_dt(comment):
         localized datetime object in timezone specified by original metadata
     """
     # extract relevant portion of comment
-    dt_str = comment.split("Recorded at ")[1].split(" by ")[0]
+    # datetime content ends after `)`
+    dt_str = comment.split("Recorded at ")[1].split(")")[0] + ")"
 
     # handle formats like "UTC-5" or "UTC+0130"
     if "UTC-" in dt_str or "UTC+" in dt_str:

--- a/tests/test_aru.py
+++ b/tests/test_aru.py
@@ -112,6 +112,25 @@ def test_parse_audiomoth_metadata_with_timezone():
     )
 
 
+def test_parse_audiomoth_metadata_with_deployment_name():
+    """sometimes comment string includes `during deployment ###`"""
+    metadata = {
+        "artist": "AudioMoth 243B1F075C7B4301",
+        "comment": "Recorded at 10:00:00 15/05/2021 (UTC) during deployment 41C351E84E9996C2 at medium gain setting while battery state was 4.7V and temperature was 3.7C.",
+        "samplerate": 32000,
+        "format": "WAV",
+        "frames": 230400000,
+        "sections": 1,
+        "subtype": "PCM_16",
+        "channels": 1,
+        "duration": 7200.0,
+    }
+    new_metadata = aru.parse_audiomoth_metadata(metadata)
+    assert new_metadata["recording_start_time"] == pytz.utc.localize(
+        datetime.datetime(2021, 5, 15, 10, 00, 00)
+    )
+
+
 def test_parse_audiomoth_metadata_with_low_battery():
     metadata = {
         "filesize": 115200360,


### PR DESCRIPTION
during parsing of AudioMoth metadata comment field: now, does not require word after datetime to be "by", instead uses `)` at end of datetime to extract relevant characters