### PR TITLE
don't fail in predict() with empty sample list

### DIFF
--- a/opensoundscape/ml/cnn.py
+++ b/opensoundscape/ml/cnn.py
@@ -84,7 +84,6 @@ class CNN(BaseModule):
         preprocessor_class=SpectrogramPreprocessor,
         sample_shape=(224, 224, 3),
     ):
-
         super(CNN, self).__init__()
 
         self.name = "CNN"
@@ -536,7 +535,6 @@ class CNN(BaseModule):
 
         # Initialize Weights and Biases (wandb) logging ###
         if wandb_session is not None:
-
             # update the run config with information about the model
             wandb_session.config.update(self._generate_wandb_config())
 
@@ -938,9 +936,6 @@ class CNN(BaseModule):
             warnings.warn(
                 "prediction_dataset has zero samples. No predictions will be generated."
             )
-            prediction_dataset = AudioFileDataset(
-                samples=[], preprocessor=self.preprocessor
-            )
 
         # If unsafe_behavior= "substitute", a SafeDataset will not fail on bad files,
         # but will provide a different sample! Later we go back and replace scores
@@ -1074,7 +1069,6 @@ class CNN(BaseModule):
 
         # Initialize Weights and Biases (wandb) logging
         if wandb_session is not None:
-
             # update the run config with information about the model
             wandb_session.config.update(self._generate_wandb_config())
 
@@ -1345,7 +1339,6 @@ class CNN(BaseModule):
             # update the AudioSample objects to include the activation maps
             # and create guided backprop maps, one at a time
             for i, sample in enumerate(samples):
-
                 if cam is None:
                     activation_maps = None
                 else:

--- a/opensoundscape/ml/datasets.py
+++ b/opensoundscape/ml/datasets.py
@@ -49,11 +49,14 @@ class AudioFileDataset(torch.utils.data.Dataset):
     """
 
     def __init__(self, samples, preprocessor, bypass_augmentations=False):
-
         ## Input Validation ##
 
         # validate type of samples: list, np array, or df
-        assert type(samples) in (list, np.ndarray, pd.DataFrame,), (
+        assert type(samples) in (
+            list,
+            np.ndarray,
+            pd.DataFrame,
+        ), (
             f"samples must be type list/np.ndarray of file paths, "
             f"or pd.DataFrame with index containing path (or multi-index of "
             f"path, start_time, end_time). Got {type(samples)}."
@@ -98,7 +101,6 @@ class AudioFileDataset(torch.utils.data.Dataset):
         return self.label_df.shape[0]
 
     def __getitem__(self, idx, break_on_key=None, break_on_type=None):
-
         sample = AudioSample.from_series(self.label_df.iloc[idx])
 
         # preprocessor.forward will raise PreprocessingError if something fails

--- a/opensoundscape/ml/datasets.py
+++ b/opensoundscape/ml/datasets.py
@@ -52,11 +52,7 @@ class AudioFileDataset(torch.utils.data.Dataset):
         ## Input Validation ##
 
         # validate type of samples: list, np array, or df
-        assert type(samples) in (
-            list,
-            np.ndarray,
-            pd.DataFrame,
-        ), (
+        assert type(samples) in (list, np.ndarray, pd.DataFrame,), (
             f"samples must be type list/np.ndarray of file paths, "
             f"or pd.DataFrame with index containing path (or multi-index of "
             f"path, start_time, end_time). Got {type(samples)}."

--- a/opensoundscape/utils.py
+++ b/opensoundscape/utils.py
@@ -1,11 +1,12 @@
 """Utilities for opensoundscape"""
 
 import datetime
+import warnings
+
 import numpy as np
 import pandas as pd
 import pytz
 import soundfile
-
 import librosa
 
 
@@ -321,10 +322,9 @@ def make_clip_df(
         )
         file_list = files
 
-    assert len(files) > 0, "files list has length zero!"
-
     clip_dfs = []
     invalid_samples = set()
+    idx_cols = ["file", "start_time", "end_time"]
     for f in file_list:
         try:
             t = librosa.get_duration(path=f)
@@ -352,7 +352,15 @@ def make_clip_df(
 
         clip_dfs.append(clips)
 
-    clip_df = pd.concat(clip_dfs).set_index(["file", "start_time", "end_time"])
+    if len(clip_dfs) > 0:
+        clip_df = pd.concat(clip_dfs).set_index(idx_cols)
+    else:
+        # warnings.warn(
+        #     f"No clips were created from file_list of length {len(file_list)}"
+        # )
+        # create an empty dataframe with the expected index and columns
+        label_cols = [] if label_df is None else label_df.columns
+        clip_df = pd.DataFrame(columns=idx_cols + label_cols).set_index(idx_cols)
 
     if return_invalid_samples:
         return clip_df, invalid_samples

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -141,6 +141,17 @@ def test_predict_on_list_of_files(test_df):
     assert len(scores) == 2
 
 
+def test_predict_on_empty_list():
+    model = cnn.CNN("resnet18", classes=[0, 1], sample_duration=5.0)
+    scores = model.predict([])
+    expected = ["file", "start_time", "end_time", 0, 1]
+    assert list(scores.reset_index().columns) == expected
+
+    scores = model.predict([], split_files_into_clips=False)
+    expected = ["index", 0, 1]
+    assert list(scores.reset_index().columns) == expected
+
+
 def test_predict_all_arch_4ch(test_df):
     for arch_name in cnn_architectures.ARCH_DICT.keys():
         try:


### PR DESCRIPTION
CNN.predict() should be ok with an empty sample list. It now gives a warning but does not cause an Exception. These changes handle both split_files_into_clips=True and False behavior. I've added a test.

Resolves AssertionError when trying to predict on empty list #747