### PR TITLE
refactor audio.extend

### DIFF
--- a/opensoundscape/preprocess/actions.py
+++ b/opensoundscape/preprocess/actions.py
@@ -195,7 +195,7 @@ def trim_audio(sample, extend=True, random_trim=False, tol=1e-5):
         if audio.duration + tol <= sample.target_duration:
             # input audio is not as long as desired length
             if extend:  # extend clip sith silence
-                audio = audio.extend(sample.target_duration)
+                audio = audio.extend_to(sample.target_duration)
             else:
                 raise ValueError(
                     f"the length of the original file ({audio.duration} "
@@ -487,7 +487,6 @@ class Overlay(Action):
     """
 
     def __init__(self, is_augmentation=True, **kwargs):
-
         super(Overlay, self).__init__(
             overlay,
             is_augmentation=is_augmentation,
@@ -617,9 +616,7 @@ def overlay(
     overlays_performed = 0
 
     while overlay_prob > np.random.uniform() and overlays_performed < max_overlay_num:
-
         try:
-
             # lets pick a sample based on rules
             if overlay_class is None:
                 # choose any file from the overlay_df

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -749,11 +749,11 @@ def test_loop(veryshort_wav_audio):
     assert math.isclose(a3.metadata["duration"], 1.0, abs_tol=1e-5)
 
 
-def test_extend(veryshort_wav_audio):
-    a = veryshort_wav_audio.extend(length=1)
+def test_extend_to_with_short(veryshort_wav_audio):
+    a = veryshort_wav_audio.extend_to(length=1)
     assert math.isclose(a.duration, 1.0, abs_tol=1e-5)
     assert math.isclose(a.metadata["duration"], 1.0, abs_tol=1e-5)
-    # samples should be zero
+    # added samples should be zero
     assert math.isclose(0.0, np.max(a.samples[-100:]), abs_tol=1e-7)
 
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -471,14 +471,49 @@ def test_resample_classmethod_vs_instancemethod(silence_10s_mp3_str):
     npt.assert_array_almost_equal(a1.samples, a2.samples, decimal=5)
 
 
-def test_extend_length_is_correct(silence_10s_mp3_str):
+def test_extend_to_length_is_correct(silence_10s_mp3_str):
     audio = Audio.from_file(silence_10s_mp3_str, sample_rate=10000)
     duration = audio.duration
     for _ in range(100):
         extend_length = random.uniform(duration, duration * 10)
         assert math.isclose(
-            audio.extend(extend_length).duration, extend_length, abs_tol=1e-4
+            audio.extend_to(extend_length).duration, extend_length, abs_tol=1e-4
         )
+
+
+def test_extend_to_correct_metadata(silence_10s_mp3_str):
+    audio = Audio.from_file(silence_10s_mp3_str, sample_rate=10000)
+    a2 = audio.extend_to(12)
+    # duration in metadata should be updated:
+    assert math.isclose(a2.metadata["duration"], 12)
+    # other metadata should be retained:
+    assert a2.metadata["subtype"] == audio.metadata["subtype"]
+
+
+def test_extend_to_shorter_duration(silence_10s_mp3_str):
+    # extending 10s to 6s should simply trim the audio
+    audio = Audio.from_file(silence_10s_mp3_str, sample_rate=10000)
+    a2 = audio.extend_to(6)
+    assert math.isclose(a2.duration, 6)
+    # duration in metadata should be updated:
+    assert math.isclose(a2.metadata["duration"], 6)
+    # other metadata should be retained:
+    assert a2.metadata["subtype"] == audio.metadata["subtype"]
+
+
+def test_extend_by(silence_10s_mp3_str):
+    audio = Audio.from_file(silence_10s_mp3_str, sample_rate=10000)
+    a2 = audio.extend_by(1)
+    assert math.isclose(a2.duration, 11)
+
+    # duration in metadata should be updated:
+    assert math.isclose(a2.metadata["duration"], 11)
+    # other metadata should be retained:
+    assert a2.metadata["subtype"] == audio.metadata["subtype"]
+
+    # doesn't allow negative extend_by(duration)
+    with pytest.raises(AssertionError):
+        a2.extend_by(-1)
 
 
 def test_bandpass(silence_10s_mp3_str):

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -750,7 +750,7 @@ def test_loop(veryshort_wav_audio):
 
 
 def test_extend_to_with_short(veryshort_wav_audio):
-    a = veryshort_wav_audio.extend_to(length=1)
+    a = veryshort_wav_audio.extend_to(duration=1)
     assert math.isclose(a.duration, 1.0, abs_tol=1e-5)
     assert math.isclose(a.metadata["duration"], 1.0, abs_tol=1e-5)
     # added samples should be zero


### PR DESCRIPTION
now two separate methods: audio.extend_to(duration) achieves desired duration, and allows duration<self.duration (trims) or >self.duration (extends with silence). audio.extend_by(duration) adds silence to the end, and does not allow duration<0.

The reason for this is that the expected behaviour of Audio.extend() is ambiguous, and also it was raising an error if duration<self.duration which caused unexpected errors.

resolves Audio.extend raises error if length < duration #695