### PR TITLE
resolve #792 no default shape

### DIFF
--- a/opensoundscape/ml/cnn.py
+++ b/opensoundscape/ml/cnn.py
@@ -150,9 +150,13 @@ class CNN(BaseModule):
             self.device = torch.device("cpu")
 
         ### sample loading/preprocessing ###
-        # preprocessor will have attributes .sample_duration and .out_shape
+        # preprocessor will have attributes .sample_duration (seconds)
+        # and height, width, channels for output shape
         self.preprocessor = preprocessor_class(
-            sample_duration=sample_duration, out_shape=sample_shape
+            sample_duration=sample_duration,
+            height=sample_shape[0],
+            width=sample_shape[1],
+            channels=sample_shape[2],
         )
 
         ### loss function ###
@@ -818,7 +822,11 @@ class CNN(BaseModule):
                 "architecture": self.architecture_name,
                 "sample_duration": self.preprocessor.sample_duration,
                 "single_target": self.single_target,
-                "sample_shape": self.preprocessor.out_shape,
+                "sample_shape": [
+                    self.preprocessor.height,
+                    self.preprocessor.width,
+                    self.preprocessor.channels,
+                ],
             },
             path,
         )

--- a/opensoundscape/preprocess/actions.py
+++ b/opensoundscape/preprocess/actions.py
@@ -244,10 +244,10 @@ class SpectrogramToTensor(BaseAction):
     def go(self, sample):
         """converts sample.data from Spectrogram to Tensor"""
         # sample.data must be Spectrogram object
-        # sample should have attribute target_shape [h,w,channels]
+        # sample should have attributes: height, width, channels
         sample.data = sample.data.to_image(
-            shape=sample.target_shape[0:2],
-            channels=sample.target_shape[2],
+            shape=[sample.height, sample.width],
+            channels=sample.channels,
             return_type="torch",
             colormap=self.params["colormap"],
             invert=self.params["invert"],

--- a/opensoundscape/preprocess/actions.py
+++ b/opensoundscape/preprocess/actions.py
@@ -478,6 +478,15 @@ def tensor_add_noise(tensor, std=1):
 class Overlay(Action):
     """Action Class for augmentation that overlays samples on eachother
 
+    Overlay is a flavor of "mixup" augmentation, where two samples are
+    overlayed on top of eachother. The samples are blended with a weighted
+    average, where the weight may be chosen randomly from a range of values.
+
+    In this implementation, the overlayed samples are chosen from a dataframe
+    of audio files and labels. The dataframe must have the audio file paths as
+    the index, and the labels as columns. The labels are used to choose
+    overlayed samples based on an "overlay_class" argument.
+
     Required Args:
         overlay_df: dataframe of audio files (index) and labels to use for overlay
         update_labels (bool): if True, labels of sample are updated to include
@@ -669,6 +678,13 @@ def overlay(
             overlay_sample = sample.preprocessor.forward(
                 overlay_sample, break_on_type=Overlay
             )
+
+            # the overlay_sample may have a different shape than the original sample
+            # force them into the same shape so we can overlay
+            if overlay_sample.data.shape != sample.data.shape:
+                overlay_sample.data = torchvision.transforms.Resize(
+                    sample.data.shape[1:]
+                )(overlay_sample.data)
 
             # now we blend the two tensors together with a weighted average
             # Select weight of overlay; <0.5 means more emphasis on original sample

--- a/opensoundscape/preprocess/preprocessors.py
+++ b/opensoundscape/preprocess/preprocessors.py
@@ -228,7 +228,7 @@ class SpectrogramPreprocessor(BasePreprocessor):
         height: height of output sample (frequency axis)
             - default None will use the original height of the spectrogram
         width: width of output sample (time axis)
-            -  default None will use the original width of the spectrogram
+            -  default None will use the originalwidth of the spectrogram
         channels: number of channels in output sample (default 1)
     """
 

--- a/opensoundscape/spectrogram.py
+++ b/opensoundscape/spectrogram.py
@@ -570,6 +570,7 @@ class Spectrogram:
         Args:
             shape: tuple of output dimensions as (height, width)
                 - if None, retains original shape of self.spectrogram
+                - if first or second value are None, retains original shape in that dimension
             channels: eg 3 for rgb, 1 for greyscale
                 - must be 3 to use colormap
             colormap:
@@ -616,8 +617,15 @@ class Spectrogram:
             array = cm(array)
 
         # resize and change channel dims
+        # if None, use original shape
         if shape is None:
             shape = np.shape(array)
+        else:
+            # if height or width are None, use original sizes
+            if shape[0] is None:
+                shape[0] = np.shape(array)[0]
+            if shape[1] is None:
+                shape[1] = np.shape(array)[1]
         out_shape = [shape[0], shape[1], channels]
         array = skimage.transform.resize(array, out_shape)
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -66,10 +66,23 @@ def test_subset_dataset(small_dataset):
 def test_audio_file_dataset(dataset_df, pre):
     """should return tensor and labels"""
     pre.bypass_augmentation = False
+    pre.height = 224
+    pre.width = 224
+    pre.channels = 3
     dataset = AudioFileDataset(dataset_df, pre)
     sample1 = dataset[0]
     assert sample1.data.numpy().shape == (3, 224, 224)
     assert dataset[0].labels.values.shape == (2,)
+
+
+def test_audio_file_dataset_no_reshape(dataset_df, pre):
+    """should return tensor and labels. Tensor is the same as the shape of the spectrogram"""
+    pre.bypass_augmentation = False
+    dataset = AudioFileDataset(dataset_df, pre)
+    sample1 = dataset[0]
+    # should be the same shape as
+    # Spectrogram.from_audio(Audio.from_file('tests/audio/silence_10s.mp3',duration=2)).bandpass(0,11025)
+    assert sample1.data.numpy().shape == (1, 129, 343)
 
 
 def test_spec_preprocessor_augment_off(dataset_df, pre):
@@ -88,7 +101,7 @@ def test_spec_preprocessor_augment_on(dataset_df, pre):
     assert not np.array_equal(sample1, sample2)
 
 
-def test_spec_preprocessor_overlay(dataset_df, overlay_df, overlay_pre):
+def test_spec_preprocessor_overlay(dataset_df, overlay_pre):
     dataset = AudioFileDataset(dataset_df, overlay_pre)
     sample1 = dataset[0].data
     dataset.preprocessor.pipeline.overlay.bypass = True

--- a/tests/test_spectrogram.py
+++ b/tests/test_spectrogram.py
@@ -202,14 +202,24 @@ def test_to_image_with_bandpass():
     )
 
 
-def test_to_image_shape():
-    img = Spectrogram(
-        spectrogram=np.zeros((5, 10)),
-        frequencies=np.linspace(0, 100, 5),
-        times=np.linspace(0, 10, 10),
-        decibel_limits=(-100, -20),
-    ).to_image(return_type="torch")
-    assert img
+def test_to_image_shape(spec):
+    img = spec.to_image(shape=[5, 6], channels=2, return_type="torch")
+    assert list(img.shape) == [2, 5, 6]  # channels, height, width
+
+
+def test_to_image_shape_None(spec):
+    """should retain original shape of spectrogram if shape=None"""
+    img = spec.to_image(shape=None, channels=2, return_type="torch")
+    spec_shape = list(spec.spectrogram.shape)
+    assert list(img.shape) == [2] + spec_shape  #  width
+
+    # test when shape specifies only desired width
+    img = spec.to_image(shape=[None, 6], channels=2, return_type="torch")
+    assert list(img.shape) == [2] + [spec_shape[0]] + [6]
+
+    # test when shape specifies only desired height
+    img = spec.to_image(shape=[5, None], channels=2, return_type="torch")
+    assert list(img.shape) == [2, 5] + [spec_shape[1]]
 
 
 def test_melspectrogram_shape_of_S_for_veryshort(veryshort_wav_str):


### PR DESCRIPTION
resolve #792: no default shape of SpecPre

changes default shape of SpectrogramPreprocessor to None, retaining the original shape of the spectrogram. However, CNN class still has default sample shape of (224,224,3) which is passed when creating the preprocessor and will continue to be the default sample shape when using the CNN class.

I also refactored the preprocessor so that the shape is given as three separate arguments (height, width, channels) for clarity instead of one. I changed the attributes added to AudioSamples to match these (.height, .width, .channels) and refactored relevant code.

Also, you can now specify None for just height or width while providing the other value, to retain just one original dimension of the spectrogram. I refactored Spectrogram.to_image to allow this behavior. 