### PR TITLE
dont log_graph in wandb.watch

### DIFF
--- a/opensoundscape/ml/cnn.py
+++ b/opensoundscape/ml/cnn.py
@@ -101,6 +101,9 @@ class CNN(BaseModule):
             n_top_samples=3,  # after prediction, log n top scoring samples per class
             # logs histograms of params & grads every n batches;
             watch_freq=10,  # use  None for no logging of params & grads
+            # log the model graph to wandb - seems to cause issues when attempting to
+            # continue training the model, so True is not recommended
+            log_graph=False,
         )
         self.loss_fn = None
         self.train_loader = None
@@ -556,7 +559,10 @@ class CNN(BaseModule):
             log_freq = self.wandb_logging["watch_freq"]
             if log_freq is not None:
                 wandb_session.watch(
-                    self.network, log="all", log_freq=log_freq, log_graph=(False)
+                    self.network,
+                    log="all",
+                    log_freq=log_freq,
+                    log_graph=(self.wandb_logging["log_graph"]),
                 )
 
             # log tables of preprocessed samples


### PR DESCRIPTION
log_graph is causing errors when trying to continue training a model. Maybe this is a wandb bug, not sure. I get the error message "ValueError: You can only call `wandb.watch` once per model.  Pass a new instance of the model if you need to call wandb.watch again in your code." This happens both if I save -> load or even just run .train() twice for the same object.

I'm just going to use False as the default value and expose it as a configuration option in cnn.wandb_logging['log_graph']