### PR TITLE
Issue 768 cam to cpu

### DIFF
--- a/opensoundscape/ml/cam.py
+++ b/opensoundscape/ml/cam.py
@@ -2,6 +2,7 @@
 import matplotlib.pyplot as plt
 import pandas as pd
 import numpy as np
+import torch
 
 
 class CAM:
@@ -31,7 +32,7 @@ class CAM:
 
         Note: activation_maps and gbp_maps will be stored as Series indexed by classes
         """
-        self.base_image = base_image
+        self.base_image = base_image.detach().cpu()
         self.activation_maps = activation_maps
         self.gbp_maps = gbp_maps
 

--- a/tests/test_cam.py
+++ b/tests/test_cam.py
@@ -12,8 +12,10 @@ import pandas as pd
 @pytest.fixture()
 def cam():
     base = torch.rand(3, 224, 224)
-    activation_maps = pd.Series({i: torch.rand(224, 224) for i in range(2)})
-    gbp_maps = pd.Series({i: torch.rand(224, 224, 3) for i in range(2)})
+    activation_maps = pd.Series(
+        {i: np.random.uniform(0, 1, [224, 224]) for i in range(2)}
+    )
+    gbp_maps = pd.Series({i: np.random.uniform(0, 1, [224, 224, 3]) for i in range(2)})
     return CAM(
         base_image=base,
         activation_maps=activation_maps,

--- a/tests/test_cam.py
+++ b/tests/test_cam.py
@@ -1,2 +1,34 @@
 # test generating cam
 # test plotting and saving
+
+# unit tests for CAM class
+import pytest
+import torch
+import numpy as np
+from opensoundscape.ml.cam import CAM
+import pandas as pd
+
+
+@pytest.fixture()
+def cam():
+    base = torch.rand(3, 224, 224)
+    activation_maps = pd.Series({i: torch.rand(224, 224) for i in range(2)})
+    gbp_maps = pd.Series({i: torch.rand(224, 224, 3) for i in range(2)})
+    return CAM(
+        base_image=base,
+        activation_maps=activation_maps,
+        gbp_maps=gbp_maps,
+    )
+
+
+def test_cam_init(cam):
+    assert isinstance(cam, CAM)
+    assert isinstance(cam.base_image, torch.Tensor)
+    assert isinstance(cam.activation_maps, pd.Series)
+    assert isinstance(cam.gbp_maps, pd.Series)
+
+
+def test_cam_plot(cam):
+    cam.plot(target_class=0)
+    cam.plot(target_class=0, mode="backprop")
+    cam.plot(target_class=0, mode="backprop_and_activation")


### PR DESCRIPTION
resolves #768 

moves CAM object's base_image tensor to CPU to avoid issues when plotting 