### PR TITLE
#769: Raven file not retained in BoxedAnnotations if keep_extra_column not set to True

### DIFF
--- a/opensoundscape/annotations.py
+++ b/opensoundscape/annotations.py
@@ -158,7 +158,7 @@ class BoxedAnnotations:
             df["raven_file"] = raven_file
 
             # remove undesired columns
-            standard_columns = ["start_time", "end_time", "low_f", "high_f"]
+            standard_columns = ["raven_file", "start_time", "end_time", "low_f", "high_f"]
             if annotation_column_idx is not None:
                 standard_columns.append("annotation")
             if hasattr(keep_extra_columns, "__iter__"):

--- a/opensoundscape/annotations.py
+++ b/opensoundscape/annotations.py
@@ -158,7 +158,13 @@ class BoxedAnnotations:
             df["raven_file"] = raven_file
 
             # remove undesired columns
-            standard_columns = ["raven_file", "start_time", "end_time", "low_f", "high_f"]
+            standard_columns = [
+                "raven_file",
+                "start_time",
+                "end_time",
+                "low_f",
+                "high_f",
+            ]
             if annotation_column_idx is not None:
                 standard_columns.append("annotation")
             if hasattr(keep_extra_columns, "__iter__"):
@@ -463,7 +469,7 @@ class BoxedAnnotations:
         # the clip_df should have ['file','start_time','end_time'] as the index
         clip_df[classes] = float("nan")  # add columns for each class
 
-        for (file, start, end) in clip_df.index:
+        for file, start, end in clip_df.index:
             if not file == file:  # file is NaN, get corresponding rows
                 file_df = df[df["audio_file"].isnull()]
             else:  # subset annotations to this file

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -140,6 +140,7 @@ def test_load_raven_annotations_different_columns(raven_file, raven_file_empty):
     assert not "type" in list(ba.df.columns)
     assert "raven_file" in list(ba.df.columns)
 
+
 def test_to_raven_files(boxed_annotations, saved_raven_file):
     """note: assumes raven file will be named audio_file.annotations.txt"""
     assert not saved_raven_file.exists()

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -120,6 +120,7 @@ def test_load_raven_annotations_different_columns(raven_file, raven_file_empty):
     )
     assert "distance" in list(ba.df.columns)
     assert "type" in list(ba.df.columns)
+    assert "raven_file" in list(ba.df.columns)
 
     # keep one extra column
     ba = BoxedAnnotations.from_raven_files(
@@ -128,6 +129,8 @@ def test_load_raven_annotations_different_columns(raven_file, raven_file_empty):
     assert "distance" in list(ba.df.columns)
     assert not "type" in list(ba.df.columns)
     # this would fail before #737 was resolved
+    assert "raven_file" in list(ba.df.columns)
+    # check for #769
 
     # keep no extra column
     ba = BoxedAnnotations.from_raven_files(
@@ -135,7 +138,7 @@ def test_load_raven_annotations_different_columns(raven_file, raven_file_empty):
     )
     assert not "distance" in list(ba.df.columns)
     assert not "type" in list(ba.df.columns)
-
+    assert "raven_file" in list(ba.df.columns)
 
 def test_to_raven_files(boxed_annotations, saved_raven_file):
     """note: assumes raven file will be named audio_file.annotations.txt"""


### PR DESCRIPTION
added raven_file to standard column list to ensure it's always retained; resolves #769 