### PR TITLE
Issue 784 boxed ann

### DIFF
--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -32,6 +32,11 @@ def saved_raven_file(request):
 
 
 @pytest.fixture()
+def save_path():
+    return Path("tests/raven_annots/")
+
+
+@pytest.fixture()
 def silence_10s_mp3_str():
     return "tests/audio/silence_10s.mp3"
 
@@ -478,11 +483,13 @@ def test_one_hot_clip_labels_with_empty_annotation_file(
     assert len(small_label_df) == 8
 
 
-def test_to_raven_files_raises_if_no_audio_files(raven_file, saved_raven_file):
+def test_to_raven_files_raises_if_no_audio_files(raven_file, save_path):
     # raises ValueError if no audio_files is provided and self.audio_files is none
     with pytest.raises(ValueError):
+        # don't save to a path with a .finalizer(), because the finalizer will complain
+        # if the file isn't actually created
         boxed_annotations = BoxedAnnotations.from_raven_files([raven_file])
-        boxed_annotations.to_raven_files(saved_raven_file.parent)
+        boxed_annotations.to_raven_files(save_path)
 
 
 def test_warn_if_file_wont_get_raven_output(raven_file, saved_raven_file):

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -37,6 +37,11 @@ def silence_10s_mp3_str():
 
 
 @pytest.fixture()
+def rugr_wav_str():
+    return "tests/audio/rugr_drum.wav"
+
+
+@pytest.fixture()
 def boxed_annotations():
     df = pd.DataFrame(
         data={
@@ -48,7 +53,7 @@ def boxed_annotations():
             "annotation": ["a", "b", None],
         }
     )
-    return BoxedAnnotations(df)
+    return BoxedAnnotations(df, audio_files=["audio_file.wav"] * 3)
 
 
 @pytest.fixture()
@@ -241,6 +246,7 @@ def test_one_hot_clip_labels_get_duration(boxed_annotations, silence_10s_mp3_str
         clip_overlap=0,
         class_subset=["a"],
         min_label_overlap=0.25,
+        audio_files=[silence_10s_mp3_str],
     )
     assert np.array_equal(labels.values, np.array([[1, 0, 0, 0, 0]]).transpose())
 
@@ -249,6 +255,7 @@ def test_one_hot_clip_labels_exception(boxed_annotations):
     """raises GetDurationError because file length cannot be determined
     and full_duration is None
     """
+    boxed_annotations.audio_files = ["non existant file"]
     with pytest.raises(GetDurationError):
         labels = boxed_annotations.one_hot_clip_labels(
             full_duration=None,
@@ -428,3 +435,63 @@ def test_methods_on_zero_length_annotations(boxed_annotations_zero_len):
 
     filtered = boxed_annotations_zero_len.subset(["a"])
     assert len(filtered.df == 1)
+
+
+def test_one_hot_clip_labels_with_empty_annotation_file(
+    raven_file_empty, silence_10s_mp3_str, raven_file, rugr_wav_str
+):
+    """test that one_hot_clip_labels works with empty annotation file
+
+    it should return a dataframe with rows for each clip and 0s for all labels
+    """
+    boxed_annotations = BoxedAnnotations.from_raven_files(
+        [raven_file_empty], [silence_10s_mp3_str]
+    )
+
+    small_label_df = boxed_annotations.one_hot_clip_labels(
+        full_duration=None,
+        clip_duration=4,
+        clip_overlap=2,
+        min_label_overlap=0.1,
+        class_subset=["EATO", "REVI"],
+        final_clip=None,
+    )
+
+    # 10 s clips has start times at 0,2,4,6 s
+    assert len(small_label_df) == 4
+    assert (small_label_df == 0).all().all()
+
+    # should also work when concatenating empty and non-empty annotation files
+    boxed_annotations = BoxedAnnotations.from_raven_files(
+        [raven_file_empty, raven_file], [silence_10s_mp3_str, rugr_wav_str]
+    )
+
+    small_label_df = boxed_annotations.one_hot_clip_labels(
+        full_duration=None,
+        clip_duration=4,
+        clip_overlap=2,
+        min_label_overlap=0.1,
+        class_subset=["EATO", "REVI"],
+        final_clip=None,
+    )
+    # should have clip entries for both clips
+    assert len(small_label_df) == 8
+
+
+def test_to_raven_files_raises_if_no_audio_files(raven_file, saved_raven_file):
+    # raises ValueError if no audio_files is provided and self.audio_files is none
+    with pytest.raises(ValueError):
+        boxed_annotations = BoxedAnnotations.from_raven_files([raven_file])
+        boxed_annotations.to_raven_files(saved_raven_file.parent)
+
+
+def test_warn_if_file_wont_get_raven_output(raven_file, saved_raven_file):
+    # should also work when concatenating empty and non-empty annotation files
+    boxed_annotations = BoxedAnnotations.from_raven_files([raven_file], ["path1"])
+    with pytest.warns(UserWarning):
+        boxed_annotations.to_raven_files(saved_raven_file.parent, audio_files=["path2"])
+
+
+def test_assert_audio_files_annotation_files_match():
+    with pytest.raises(AssertionError):
+        BoxedAnnotations.from_raven_files(["path"], [])

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -489,7 +489,9 @@ def test_warn_if_file_wont_get_raven_output(raven_file, saved_raven_file):
     # should also work when concatenating empty and non-empty annotation files
     boxed_annotations = BoxedAnnotations.from_raven_files([raven_file], ["path1"])
     with pytest.warns(UserWarning):
-        boxed_annotations.to_raven_files(saved_raven_file.parent, audio_files=["path2"])
+        boxed_annotations.to_raven_files(
+            saved_raven_file.parent, audio_files=["audio_file"]
+        )
 
 
 def test_assert_audio_files_annotation_files_match():


### PR DESCRIPTION
Resolves #784

There was a bug causing BoxedAnnotations.one_hot_clip_labels to not give any clips when a file doesn't have any annotations. We need to keep a list of audio_files for which we want clips (since the .df of BoxedAnnotations doesn't have any rows for any files without annotations). I refactored the `.one_hot_clip_labels()` method and `.to_raven_files()` to take an argument `audio_files`. The default value `None` will use the BoxedAnnotation object's `.audio_files` attribute, a list of audio files. Note that the files have to match the `audio_file` column of self.df for .to_raven_files() to know which annotations to save to each file. 

This could be a bit clunky for some use-cases: what if you don't associate with audio files, but just want to export raven files? You need to put placeholder files for the `audio_file` column of `.df`. 