### PR TITLE
use local version of ScoreCAM with bug fix

### DIFF
--- a/opensoundscape/ml/utils.py
+++ b/opensoundscape/ml/utils.py
@@ -4,7 +4,8 @@ import pandas as pd
 import numpy as np
 import torch
 import torch.nn.functional as F
-
+from pytorch_grad_cam.base_cam import BaseCAM
+import tqdm
 
 from opensoundscape.ml.sampling import ClassAwareSampler
 
@@ -118,8 +119,12 @@ def apply_activation_layer(x, activation_layer=None):
             - 'softmax_and_logit': apply softmax then logit transform
     Returns:
         values with activation layer applied
-
+        Note: if x is None, returns None
     """
+    if x is None:
+        return None
+
+    x = torch.tensor(x)
     if activation_layer is None:  # scores [-inf,inf]
         pass
     elif activation_layer == "softmax":
@@ -142,3 +147,54 @@ def apply_activation_layer(x, activation_layer=None):
         raise ValueError(f"invalid option for activation_layer: {activation_layer}")
 
     return x
+
+
+# override pytorch_grad_cam's score cam class because it has a bug
+# with device mismatch of upsampled (cpu) vs input_tensor (may be mps, cuda, etc)
+class ScoreCAM(BaseCAM):
+    def __init__(self, model, target_layers, use_cuda=False, reshape_transform=None):
+        super(ScoreCAM, self).__init__(
+            model,
+            target_layers,
+            use_cuda,
+            reshape_transform=reshape_transform,
+            uses_gradients=False,
+        )
+
+    def get_cam_weights(self, input_tensor, target_layer, targets, activations, grads):
+        with torch.no_grad():
+            upsample = torch.nn.UpsamplingBilinear2d(size=input_tensor.shape[-2:])
+            activation_tensor = torch.from_numpy(activations)
+            if self.cuda:
+                activation_tensor = activation_tensor.cuda()
+
+            upsampled = upsample(activation_tensor)
+
+            maxs = upsampled.view(upsampled.size(0), upsampled.size(1), -1).max(dim=-1)[
+                0
+            ]
+            mins = upsampled.view(upsampled.size(0), upsampled.size(1), -1).min(dim=-1)[
+                0
+            ]
+
+            maxs, mins = maxs[:, :, None, None], mins[:, :, None, None]
+            upsampled = (upsampled - mins) / (maxs - mins)
+
+            upsampled = upsampled.to(input_tensor.device)
+            input_tensors = input_tensor[:, None, :, :] * upsampled[:, :, None, :, :]
+
+            if hasattr(self, "batch_size"):
+                BATCH_SIZE = self.batch_size
+            else:
+                BATCH_SIZE = 16
+
+            scores = []
+            for target, tensor in zip(targets, input_tensors):
+                for i in tqdm.tqdm(range(0, tensor.size(0), BATCH_SIZE)):
+                    batch = tensor[i : i + BATCH_SIZE, :]
+                    outputs = [target(o).cpu().item() for o in self.model(batch)]
+                    scores.extend(outputs)
+            scores = torch.Tensor(scores)
+            scores = scores.view(activations.shape[0], activations.shape[1])
+            weights = torch.nn.Softmax(dim=-1)(scores).numpy()
+            return weights


### PR DESCRIPTION
pytorch_grad_cam's score_cam has a bug where there's a device mismatch. Until its fixed (see https://github.com/jacobgil/pytorch-grad-cam/issues/455) I've implemented the class with the fix in opensoundscape.ml.utils