### PR TITLE
fix Audio.from_url raising AxisError #837

### DIFF
--- a/opensoundscape/audio.py
+++ b/opensoundscape/audio.py
@@ -29,6 +29,7 @@ import numpy as np
 import scipy
 
 import librosa
+import librosa.core.audio
 import soundfile
 import IPython.display
 from aru_metadata_parser.parse import parse_audiomoth_metadata
@@ -407,7 +408,10 @@ class Audio:
         samples, original_sample_rate = soundfile.read(
             io.BytesIO(urllib.request.urlopen(url).read())
         )
-        samples = samples.mean(1)  # sum to mono
+
+        # sum to mono, if multiple channels
+        samples = librosa.core.audio.to_mono(samples.transpose())
+
         if sample_rate is not None and sample_rate != original_sample_rate:
             samples = librosa.resample(
                 samples,

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -851,3 +851,12 @@ def test_estimate_delay_return_cc_max(veryshort_audio):
         ccmax, sum(section_used.samples * section_used.samples), abs_tol=1e-5
     )
     assert math.isclose(delay, 0, abs_tol=1e-6)
+
+
+def test_from_url_multichannel_to_mono():
+    """note: test will fail if the file is removed from xeno-canto
+    or is inaccessible at this url
+
+    downloads a 2-channel audio file and sums to 1, ensuring resolution of #837
+    """
+    Audio.from_url("https://xeno-canto.org/830406/download")


### PR DESCRIPTION
since soundfile returns 2d array for multichannel and 1d array for single channel audio, need some logic when averaging channels to mono. Instead of re-implementing, I chose to use librosa.core.audio.to_mono. I added a test that downloads a xeno-canto file - the test may fail if that file ever becomes unavailable at the URL.

resulves #837 