### PR TITLE
Issue 840 posix paths

### DIFF
--- a/opensoundscape/ml/safe_dataset.py
+++ b/opensoundscape/ml/safe_dataset.py
@@ -130,7 +130,7 @@ class SafeDataset:
             if log is not None:
                 with open(log, "w") as f:
                     for p in self._invalid_samples:
-                        f.write(p + "\n")
+                        f.write(f"{p} \n")
                 msg += f"The invalid file paths are logged in {log}"
             warnings.warn(msg)
         return self._invalid_samples

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -524,3 +524,25 @@ def test_generate_cams_target_layers(test_df):
     _ = model.generate_cams(
         test_df, target_layers=[model.network.layer3, model.network.layer4]
     )
+
+
+def test_train_with_posixpath(train_df):
+    """test that train works with pathlib.Path objects"""
+    from pathlib import Path
+
+    model = cnn.CNN("resnet18", classes=[0, 1], sample_duration=5.0)
+
+    # turn the file paths into Path objects. They are the first level in the multiindex
+    posix_paths = [Path(p) for p in train_df.index.get_level_values(0)]
+    posix_path_index = train_df.index.set_levels(posix_paths, level=0)
+
+    model.train(
+        train_df,
+        train_df,
+        save_path=Path("tests/models"),
+        epochs=1,
+        batch_size=2,
+        save_interval=10,
+        num_workers=0,
+    )
+    shutil.rmtree("tests/models/")

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -532,9 +532,11 @@ def test_train_with_posixpath(train_df):
 
     model = cnn.CNN("resnet18", classes=[0, 1], sample_duration=5.0)
 
-    # turn the file paths into Path objects. They are the first level in the multiindex
-    posix_paths = [Path(p) for p in train_df.index.get_level_values(0)]
-    posix_path_index = train_df.index.set_levels(posix_paths, level=0)
+    # turn the file paths into Path objects.
+    posix_paths = [Path(p) for p in train_df.index]
+
+    # change the index of train_df to be the Path objects
+    train_df.index = posix_paths
 
     model.train(
         train_df,
@@ -545,4 +547,27 @@ def test_train_with_posixpath(train_df):
         save_interval=10,
         num_workers=0,
     )
+
     shutil.rmtree("tests/models/")
+
+
+def test_predict_posixpath_missing_files(missing_file_df, test_df):
+    """Test that predict works with pathlib.Path objects"""
+    model = cnn.CNN("resnet18", classes=[0, 1], sample_duration=5.0)
+
+    missing_file_df.index = [Path(p) for p in missing_file_df.index]
+    test_df.index = [Path(p) for p in test_df.index]
+    with pytest.raises(IndexError):
+        # if all samples are invalid, will give IndexError
+        model.predict(missing_file_df)
+
+    scores, invalid_samples = model.predict(
+        pd.concat([missing_file_df, test_df.head(1)]), return_invalid_samples=True
+    )
+    assert (
+        len(scores) == 3
+    )  # should have one row with nan values for the invalid sample
+    isnan = lambda x: x != x
+    assert np.all([isnan(score) for score in scores.iloc[0].values])
+    assert len(invalid_samples) == 1
+    assert missing_file_df.index.values[0] in invalid_samples


### PR DESCRIPTION
Fixes the issue that using posix paths for model training/prediction would raise a cryptic error. Now Posix path objects can be used interchangeably with strings of filepaths.