### PR TITLE
MPS memory issue on github macos runner workarouns

### DIFF
--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -56,6 +56,8 @@ jobs:
         run: curl -sSL https://install.python-poetry.org | python
       - name: Poetry install
         run: /Users/runner/.local/bin/poetry install
+      - name: MPS_memory_workaround
+	run: export PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
       - name: Poetry run pytest
         run: /Users/runner/.local/bin/poetry run pytest
       - name: Poetry run black check

--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -56,7 +56,7 @@ jobs:
         run: curl -sSL https://install.python-poetry.org | python
       - name: Poetry install
         run: /Users/runner/.local/bin/poetry install
-      - name: MPS_memory_workaround
+      - name: MPS memoery workaround
 	run: export PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
       - name: Poetry run pytest
         run: /Users/runner/.local/bin/poetry run pytest

--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -56,8 +56,8 @@ jobs:
         run: curl -sSL https://install.python-poetry.org | python
       - name: Poetry install
         run: /Users/runner/.local/bin/poetry install
-      - name: MPS memoery workaround
-	run: export PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
+      - name: MPS memory workaround
+        run: export PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
       - name: Poetry run pytest
         run: /Users/runner/.local/bin/poetry run pytest
       - name: Poetry run black check


### PR DESCRIPTION
A number of github runs have been failing due an MPS out of memory issue. See #850 

This PR contains the suggested workaround from the error message. The workaround just sets this variable in the MacOS runner environment
```
export PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
```