### PR TITLE
Add GradCAM visualization to wandb during CNN.predict

### DIFF
--- a/opensoundscape/logging.py
+++ b/opensoundscape/logging.py
@@ -88,7 +88,7 @@ def wandb_table(
             samples = gradcam_model.generate_cams(samples, classes=[c])
             cam_images = []
             for s in samples:
-                array = s.cam.plot(class_subset=[c], return_numpy=True, plt_show=False)
+                array = s.cam.create_rgb_heatmaps(class_subset=[c])
                 cam_images.append(wandb.Image(array))
             sample_table[f"{c} GradCAM"] = cam_images
 

--- a/opensoundscape/logging.py
+++ b/opensoundscape/logging.py
@@ -12,6 +12,7 @@ def wandb_table(
     random_state=None,
     raise_exceptions=False,
     drop_labels=False,
+    gradcam_model=None,
 ):
     """Generate a wandb Table visualizing n random samples from a sample_df
 
@@ -23,6 +24,7 @@ def wandb_table(
         classes_to_extract: tuple of classes - will create columns containing the scores/labels
         random_state: default None; if integer provided, used for reproducible random sample
         drop_labels: if True, does not include 'label' column in Table
+        gradcam_model: if not None, will generate GradCAMs for each sample using gradcam_model.get_cams()
 
     Returns: a W&B Table of preprocessed samples with labels and playable audio
 
@@ -42,6 +44,8 @@ def wandb_table(
         table_columns += ["clip duration"]
     for c in classes_to_extract:
         table_columns += c
+        if gradcam_model is not None:
+            table_columns += f"{c} GradCAM"
 
     sample_table = pd.DataFrame(columns=table_columns)
     for i in range(len(dataset)):
@@ -78,6 +82,17 @@ def wandb_table(
         except:  # by default, ignore exceptions
             if raise_exceptions:
                 raise
+
+    # add GradCAMs to table
+    if gradcam_model is not None:
+        for c in classes_to_extract:
+            samples = dataset.dataset.df
+            samples = gradcam_model.get_cams(samples, c)
+            cam_images = []
+            for s in samples:
+                array = s.cam.plot(class_subset=[c], return_numpy=True, plt_show=False)
+                cam_images.append(wandb.Image(array))
+            sample_table[f"{c} GradCAM"] = cam_images
 
     if drop_labels:
         sample_table = sample_table.drop(columns=["labels"])

--- a/opensoundscape/logging.py
+++ b/opensoundscape/logging.py
@@ -43,9 +43,7 @@ def wandb_table(
         table_columns += ["clip start time"]
         table_columns += ["clip duration"]
     for c in classes_to_extract:
-        table_columns += c
-        if gradcam_model is not None:
-            table_columns += f"{c} GradCAM"
+        table_columns.append(c)
 
     sample_table = pd.DataFrame(columns=table_columns)
     for i in range(len(dataset)):
@@ -86,8 +84,8 @@ def wandb_table(
     # add GradCAMs to table
     if gradcam_model is not None:
         for c in classes_to_extract:
-            samples = dataset.dataset.df
-            samples = gradcam_model.get_cams(samples, c)
+            samples = dataset.label_df
+            samples = gradcam_model.generate_cams(samples, classes=[c])
             cam_images = []
             for s in samples:
                 array = s.cam.plot(class_subset=[c], return_numpy=True, plt_show=False)

--- a/opensoundscape/ml/cnn.py
+++ b/opensoundscape/ml/cnn.py
@@ -1227,7 +1227,8 @@ class CNN(BaseClassifier):
                 raise_errors, overlap_fraction, final_clip, other DataLoader args)
 
         Returns:
-            a list of cam class activation objects. see the cam class for more details
+            a list of AudioSample objects with .cam attribute, an instance of the CAM class (
+            visualize with `sample.cam.plot()`). See the CAM class for more details
 
         See pytorch_grad_cam documentation for references to the source of each method.
         """
@@ -1328,10 +1329,7 @@ class CNN(BaseClassifier):
                     batch_maps = pd.Series({None: cam(batch_tensors)})
                 else:  # one activation map per class
                     batch_maps = pd.Series(
-                        {
-                            c: cam(batch_tensors, targets=target(c).to(self.device))
-                            for c in classes
-                        }
+                        {c: cam(batch_tensors, targets=target(c)) for c in classes}
                     )
 
             # update the AudioSample objects to include the activation maps

--- a/opensoundscape/ml/cnn.py
+++ b/opensoundscape/ml/cnn.py
@@ -264,7 +264,7 @@ class BaseClassifier(torch.nn.Module):
                     classes_to_extract=[c],
                     drop_labels=True,
                     gradcam_model=self if self.wandb_logging["gradcam"] else None,
-                    raise_exceptions=True,
+                    raise_exceptions=True,  # TODO back to false when done debugging
                 )
                 wandb_session.log({f"Samples / Top scoring [{c}]": table})
 

--- a/opensoundscape/ml/cnn.py
+++ b/opensoundscape/ml/cnn.py
@@ -1368,6 +1368,13 @@ class CNN(BaseClassifier):
                                 for c in classes
                             }
                         )
+
+                    # average the guided backprop map over the channel dimension
+                    def avg_over_channels(img):
+                        return img.mean(axis=-1)
+
+                    gbp_maps = gbp_maps.apply(avg_over_channels)
+
                 else:  # no guided backprop requested
                     gbp_maps = None
 

--- a/opensoundscape/ml/cnn.py
+++ b/opensoundscape/ml/cnn.py
@@ -264,6 +264,7 @@ class BaseClassifier(torch.nn.Module):
                     classes_to_extract=[c],
                     drop_labels=True,
                     gradcam_model=self if self.wandb_logging["gradcam"] else None,
+                    raise_exceptions=True,
                 )
                 wandb_session.log({f"Samples / Top scoring [{c}]": table})
 
@@ -440,18 +441,6 @@ class CNN(BaseClassifier):
         self.classes = classes
         self.single_target = single_target  # if True: predict only class w max score
         self.opensoundscape_version = opensoundscape.__version__
-
-        # number of samples to preprocess and log to wandb during train/predict
-        self.wandb_logging = dict(
-            n_preview_samples=8,  # before train/predict, log n random samples
-            top_samples_classes=None,  # specify list of classes to see top samples from
-            n_top_samples=3,  # after prediction, log n top scoring samples per class
-            # logs histograms of params & grads every n batches;
-            watch_freq=10,  # use  None for no logging of params & grads
-            # log the model graph to wandb - seems to cause issues when attempting to
-            # continue training the model, so True is not recommended
-            log_graph=False,
-        )
         self.scheduler = None
 
         # to use a custom DataLoader or Sampler, change these attributes

--- a/opensoundscape/utils.py
+++ b/opensoundscape/utils.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytz
 import soundfile
 import librosa
+from matplotlib.colors import LinearSegmentedColormap
 
 
 class GetDurationError(ValueError):
@@ -313,3 +314,18 @@ def make_clip_df(
         return clip_df, invalid_samples
     else:
         return clip_df
+
+
+def generate_opacity_colormaps(
+    colors=["#067bc2", "#43a43d", "#ecc30b", "#f37748", "#d56062"]
+):
+    """Create a colormap for each color from transparent to opaque"""
+    colormaps = []
+
+    for color in colors:
+        cmap = LinearSegmentedColormap.from_list(
+            "custom_cmap", [(0, 0, 0, 0), color], N=256
+        )
+        colormaps.append(cmap)
+
+    return colormaps

--- a/tests/test_cam.py
+++ b/tests/test_cam.py
@@ -31,6 +31,8 @@ def test_cam_init(cam):
 
 
 def test_cam_plot(cam):
-    cam.plot(target_class=0)
-    cam.plot(target_class=0, mode="backprop")
-    cam.plot(target_class=0, mode="backprop_and_activation")
+    cam.plot()
+    cam.plot(class_subset=[0])
+    cam.plot(class_subset=(0, 1))
+    cam.plot(class_subset=(0,), mode="backprop")
+    cam.plot(class_subset=(0,), mode="backprop_and_activation")

--- a/tests/test_cam.py
+++ b/tests/test_cam.py
@@ -15,7 +15,7 @@ def cam():
     activation_maps = pd.Series(
         {i: np.random.uniform(0, 1, [224, 224]) for i in range(2)}
     )
-    gbp_maps = pd.Series({i: np.random.uniform(0, 1, [224, 224, 3]) for i in range(2)})
+    gbp_maps = pd.Series({i: np.random.uniform(0, 1, [224, 224]) for i in range(2)})
     return CAM(
         base_image=base,
         activation_maps=activation_maps,

--- a/tests/test_preprocess_utils.py
+++ b/tests/test_preprocess_utils.py
@@ -14,7 +14,7 @@ def test_get_args():
         "tensor": inspect._empty,
         "channel": None,
         "transform_from_zero_centered": True,
-        "invert": True,
+        "invert": False,
     }
     assert args == expected_args
 


### PR DESCRIPTION
It works! 

CNN.predict() now logs gradcam visualizations for top-scoring samples from each class selected based on the `.wandb_logging['top_samples_classes']` attribute of the CNN class