### PR TITLE
refactor safe_dataset resolve #672

### DIFF
--- a/opensoundscape/ml/safe_dataset.py
+++ b/opensoundscape/ml/safe_dataset.py
@@ -163,7 +163,7 @@ class SafeDataset:
             while attempts < len(self.dataset):
                 sample_or_exc = self._safe_get_item(idx)
                 if not isinstance(sample_or_exc, Exception):
-                    return sample
+                    return sample_or_exc
                 idx += 1
                 attempts += 1
                 idx = idx % len(self.dataset)  # loop around end to beginning


### PR DESCRIPTION
"No safe samples" exception in SafeDataset should include traceback of (last?) error #672

now _safe_get_item returns the sample or the exception raised, rather than the sample or None. This makes it easier to debug because you can inspect or raise the exc, or raise a new exception from the exc.

In __getitem__, if all samples fail to load the raised exception is rased _from_ the most recent preprocessing exception so that the user can inspect the preprocessing exception