### PR TITLE
Issue_872_annotations

### DIFF
--- a/opensoundscape/annotations.py
+++ b/opensoundscape/annotations.py
@@ -31,7 +31,7 @@ class BoxedAnnotations:
     trim() [limit time range] and bandpass() [limit frequency range]
     """
 
-    def __init__(self, df, raven_files=None, audio_files=None):
+    def __init__(self, df, annotation_files=None, audio_files=None):
         """
         create object directly from DataFrame of frequency-time annotations
 
@@ -47,9 +47,8 @@ class BoxedAnnotations:
                 - "low_f": lower frequency bound (values can be None/nan)
                 - "high_f": upper frequency bound (values can be None/nan)
                 Note: other columns will be retained in the .df
-
-            raven_files: list of raven .txt file paths (as str or pathlib.Path)
-                or None [default: None]
+            annotation_files: list of annotation file paths (as str or pathlib.Path)
+                (e.g., raven .txt files) or None [default: None]
             audio_files: list of audio file paths (as str or pathlib.Path)
                 or None [default: None]
 
@@ -58,12 +57,12 @@ class BoxedAnnotations:
 
         """
         # save lists
-        self.raven_files = raven_files
+        self.annotation_files = annotation_files
         self.audio_files = audio_files
 
         standard_cols = [
             "audio_file",
-            "raven_file",
+            "annotation_file",
             "annotation",
             "start_time",
             "end_time",
@@ -203,11 +202,11 @@ class BoxedAnnotations:
                 ) from e
 
             # add column containing the raven file path
-            df["raven_file"] = raven_file
+            df["annotation_file"] = raven_file
 
             # remove undesired columns
             standard_columns = [
-                "raven_file",
+                "annotation_file",
                 "start_time",
                 "end_time",
                 "low_f",
@@ -244,7 +243,7 @@ class BoxedAnnotations:
 
         return cls(
             df=all_annotations,
-            raven_files=raven_files,
+            annotation_files=raven_files,
             audio_files=audio_files,
         )
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -58,7 +58,11 @@ def boxed_annotations():
             "annotation": ["a", "b", None],
         }
     )
-    return BoxedAnnotations(df, audio_files=["audio_file.wav"] * 3)
+    return BoxedAnnotations(
+        df,
+        audio_files=["audio_file.wav"] * 3,
+        annotation_files=["audio_file.annotations.txt"] * 3,
+    )
 
 
 @pytest.fixture()
@@ -159,7 +163,11 @@ def test_to_raven_files(boxed_annotations, saved_raven_file):
 
 
 def test_subset(boxed_annotations):
-    assert len(boxed_annotations.subset(["a", None]).df) == 2
+    subset = boxed_annotations.subset(["a", None])
+    assert len(subset.df) == 2
+    # should retain .audio_files and .annotation_files
+    assert subset.audio_files == boxed_annotations.audio_files
+    assert subset.annotation_files == boxed_annotations.annotation_files
 
 
 def test_subset_to_nan(raven_file):
@@ -172,6 +180,10 @@ def test_trim(boxed_annotations):
     assert len(trimmed.df) == 2
     assert np.max(trimmed.df["end_time"]) == 3.0
     assert np.min(trimmed.df["start_time"]) == 0.0
+
+    # should retain .audio_files and .annotation_files
+    assert trimmed.audio_files == boxed_annotations.audio_files
+    assert trimmed.annotation_files == boxed_annotations.annotation_files
 
 
 def test_trim_keep(boxed_annotations):
@@ -191,6 +203,9 @@ def test_bandpass(boxed_annotations):
     assert len(bandpassed.df) == 2
     assert np.max(bandpassed.df["high_f"]) == 1400
     assert np.min(bandpassed.df["low_f"]) == 600
+    # should retain .audio_files and .annotation_files
+    assert bandpassed.audio_files == boxed_annotations.audio_files
+    assert bandpassed.annotation_files == boxed_annotations.annotation_files
 
 
 def test_bandpass_keep(boxed_annotations):

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -130,7 +130,7 @@ def test_load_raven_annotations_different_columns(raven_file, raven_file_empty):
     )
     assert "distance" in list(ba.df.columns)
     assert "type" in list(ba.df.columns)
-    assert "raven_file" in list(ba.df.columns)
+    assert "annotation_file" in list(ba.df.columns)
 
     # keep one extra column
     ba = BoxedAnnotations.from_raven_files(
@@ -139,7 +139,7 @@ def test_load_raven_annotations_different_columns(raven_file, raven_file_empty):
     assert "distance" in list(ba.df.columns)
     assert not "type" in list(ba.df.columns)
     # this would fail before #737 was resolved
-    assert "raven_file" in list(ba.df.columns)
+    assert "annotation_file" in list(ba.df.columns)
     # check for #769
 
     # keep no extra column
@@ -148,7 +148,7 @@ def test_load_raven_annotations_different_columns(raven_file, raven_file_empty):
     )
     assert not "distance" in list(ba.df.columns)
     assert not "type" in list(ba.df.columns)
-    assert "raven_file" in list(ba.df.columns)
+    assert "annotation_file" in list(ba.df.columns)
 
 
 def test_to_raven_files(boxed_annotations, saved_raven_file):


### PR DESCRIPTION
resolves BoxedAnnotations.subset does not retain audio_files #872

used a _spawn method like Audio and Spectrogram classes, added __slots__, and use the spawn method for out-of-place methods that create a new BoxedAnnotations object (Spawn retains unmodified attributes and will work even if the class is sub-classed)

also added missing self.df.copy() lines to ensure the original object's .df is never modified during an out-of-place method that creates a new object