### PR TITLE
check for labels outside range [0,1]

### DIFF
--- a/opensoundscape/ml/cnn.py
+++ b/opensoundscape/ml/cnn.py
@@ -20,7 +20,7 @@ from tqdm.autonotebook import tqdm
 
 import opensoundscape
 from opensoundscape.ml import cnn_architectures
-from opensoundscape.ml.utils import apply_activation_layer
+from opensoundscape.ml.utils import apply_activation_layer, check_labels
 from opensoundscape.preprocess.preprocessors import SpectrogramPreprocessor
 from opensoundscape.ml.loss import (
     BCEWithLogitsLoss_hot,
@@ -365,7 +365,15 @@ class BaseClassifier(torch.nn.Module):
             scores: continuous values in 0/1 for each sample and class
             logging_offset: modify verbosity - for example, -1 will reduce
                 the amount of printing/logging by 1 level
+
+        Raises:
+            AssertionError: if targets are outside of range [0,1]
         """
+
+        # check for invalid label values
+        assert (
+            targets.max(axis=None) <= 1 and targets.min(axis=None) >= 0
+        ), "Labels must in range [0,1], but found values outside range"
 
         # remove all samples with NaN for a prediction
         targets = targets[~np.isnan(scores).any(axis=1), :]
@@ -802,9 +810,9 @@ class CNN(BaseClassifier):
             `train_df=train_df[cnn.classes]` or `cnn.classes=train_df.columns` 
             before training.
             """
-        assert list(self.classes) == list(train_df.columns), class_err
+        check_labels(train_df, self.classes)
         if validation_df is not None:
-            assert list(self.classes) == list(validation_df.columns), class_err
+            check_labels(validation_df, self.classes)
 
         # Validation: warn user if no validation set
         if validation_df is None:

--- a/opensoundscape/ml/utils.py
+++ b/opensoundscape/ml/utils.py
@@ -1,4 +1,5 @@
 """Utilties for .ml"""
+
 import warnings
 import pandas as pd
 import numpy as np
@@ -215,3 +216,17 @@ def collate_audio_samples_to_tensors(batch):
     tensors = torch.stack([i.data for i in batch])
     labels = torch.tensor([i.labels.tolist() for i in batch])
     return tensors, labels
+
+
+def check_labels(label_df, classes):
+    class_err = """
+            Train and validation datasets must have same classes
+            and class order as model object. Consider using
+            `train_df=train_df[cnn.classes]` or `cnn.classes=train_df.columns` 
+            before training.
+            """
+    assert list(classes) == list(label_df.columns), class_err
+
+    assert (
+        label_df.max(axis=None) <= 1 and label_df.min(axis=None) >= 0
+    ), "Labels must in range [0,1], but found values outside range"

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -402,6 +402,21 @@ def test_prediction_warns_different_classes(train_df):
         assert "classes" in all_warnings
 
 
+def test_train_raises_wrong_class_list(train_df):
+    model = cnn.CNN("resnet18", classes=["different"], sample_duration=5.0)
+    with pytest.raises(AssertionError):
+        # raises AssertionError bc test_df columns != model.classes
+        model.train(train_df)
+
+
+def test_train_raises_labels_outside_range(train_df):
+    model = cnn.CNN("resnet18", classes=[0, 1], sample_duration=5.0)
+    train_df.iat[0, 0] = 2
+    with pytest.raises(AssertionError):
+        # raises AssertionError bc values outside [0,1] not allowed
+        model.train(train_df)
+
+
 def test_prediction_returns_consistent_values(train_df):
     model = cnn.CNN("resnet18", classes=["a", "b"], sample_duration=5.0)
     a = model.predict(train_df)
@@ -425,6 +440,15 @@ def test_eval(train_df):
     model = cnn.CNN("resnet18", classes=[0, 1], sample_duration=2)
     scores = model.predict(train_df, split_files_into_clips=False)
     model.eval(train_df.values, scores.values)
+
+
+def test_eval_raises_bad_labels(train_df):
+    model = cnn.CNN("resnet18", classes=[0, 1], sample_duration=2)
+    scores = model.predict(train_df, split_files_into_clips=False)
+    train_df.iat[0, 0] = 2
+    with pytest.raises(AssertionError):
+        # raises AssertionError bc values outside [0,1] not allowed
+        model.eval(train_df.values, scores.values)
 
 
 def test_split_resnet_feat_clf(train_df):


### PR DESCRIPTION
resolves check for values other than 0/1 in labels #891

now asserts that label values are >=0 and <=1 during CNN.train() and CNN.eval(). Adds tests for both. Also adds a missing test for input validation check of wrong class list during CNN.train()