### PR TITLE
more flexible specification of overlap

### DIFF
--- a/opensoundscape/ml/cnn.py
+++ b/opensoundscape/ml/cnn.py
@@ -43,6 +43,8 @@ from opensoundscape.metrics import (
     multi_target_metrics,
 )
 
+import warnings
+
 
 class BaseClassifier(torch.nn.Module):
     """
@@ -105,7 +107,10 @@ class BaseClassifier(torch.nn.Module):
         num_workers=0,
         activation_layer=None,
         split_files_into_clips=True,
-        overlap_fraction=0,
+        clip_overlap=None,
+        clip_overlap_fraction=None,
+        clip_step=None,
+        overlap_fraction=None,
         final_clip=None,
         bypass_augmentations=True,
         invalid_samples_log=None,
@@ -145,10 +150,9 @@ class BaseClassifier(torch.nn.Module):
             split_files_into_clips:
                 If True, internally splits and predicts on clips from longer audio files
                 Otherwise, assumes each row of `samples` corresponds to one complete sample
-            overlap_fraction: fraction of overlap between consecutive clips when
-                predicting on clips of longer audio files. For instance, 0.5
-                gives 50% overlap between consecutive clips.
-            final_clip: see `opensoundscape.utils.generate_clip_times_df`
+            clip_overlap_fraction, clip_overlap, clip_step, final_clip:
+                see `opensoundscape.utils.generate_clip_times_df`
+            overlap_fraction: deprecated alias for clip_overlap_fraction
             bypass_augmentations: If False, Actions with
                 is_augmentation==True are performed. Default True.
             invalid_samples_log: if not None, samples that failed to preprocess
@@ -188,7 +192,7 @@ class BaseClassifier(torch.nn.Module):
             for that sample will be np.nan
 
         """
-        # for convenience, convert str/pathlib.Path to list
+        # for convenience, convert str/pathlib.Path to list of length 1
         if isinstance(samples, (str, Path)):
             samples = [samples]
 
@@ -198,6 +202,9 @@ class BaseClassifier(torch.nn.Module):
             self.preprocessor,
             split_files_into_clips=split_files_into_clips,
             overlap_fraction=overlap_fraction,
+            clip_overlap=clip_overlap,
+            clip_overlap_fraction=clip_overlap_fraction,
+            clip_step=clip_step,
             final_clip=final_clip,
             bypass_augmentations=bypass_augmentations,
             batch_size=batch_size,
@@ -577,7 +584,7 @@ class CNN(BaseClassifier):
             train_df,
             self.preprocessor,
             split_files_into_clips=True,
-            overlap_fraction=0,
+            clip_overlap=0,
             final_clip=None,
             bypass_augmentations=False,
             batch_size=batch_size,

--- a/opensoundscape/ml/datasets.py
+++ b/opensoundscape/ml/datasets.py
@@ -1,4 +1,5 @@
 """Preprocessors: pd.Series child with an action sequence & forward method"""
+
 import warnings
 import copy
 from pathlib import Path
@@ -161,10 +162,11 @@ class AudioSplittingDataset(AudioFileDataset):
     automatically split longer files into clips (providing only the file paths).
 
     Args:
-        see AudioFileDataset and make_clip_df
+        samples and preprocessor are passed to AudioFileDataset.__init__
+        **kwargs are passed to opensoundscape.utils.make_clip_df
     """
 
-    def __init__(self, samples, preprocessor, overlap_fraction=0, final_clip=None):
+    def __init__(self, samples, preprocessor, **kwargs):
         super(AudioSplittingDataset, self).__init__(
             samples=samples, preprocessor=preprocessor
         )
@@ -177,7 +179,6 @@ class AudioSplittingDataset(AudioFileDataset):
         self.label_df, self.invalid_samples = make_clip_df(
             files=samples,
             clip_duration=preprocessor.sample_duration,
-            clip_overlap=overlap_fraction * preprocessor.sample_duration,
-            final_clip=final_clip,
             return_invalid_samples=True,
+            **kwargs,
         )

--- a/opensoundscape/ribbit.py
+++ b/opensoundscape/ribbit.py
@@ -2,6 +2,7 @@
 
 This module provides functionality to search audio for periodically fluctuating vocalizations.
 """
+
 import os
 import warnings
 
@@ -76,7 +77,9 @@ def ribbit(
     signal_band,
     pulse_rate_range,
     clip_duration,
-    clip_overlap=0,
+    clip_overlap=None,
+    clip_overlap_fraction=None,
+    clip_step=None,
     final_clip=None,
     noise_bands=None,
     spec_clip_range=(-100, -20),
@@ -93,8 +96,13 @@ def ribbit(
         pulse_rate_range: [min,max] pulses per second for the target species
         clip_duration: the length of audio (in seconds) to analyze at one time
             - each clip is analyzed independently and recieves a ribbit score
-        clip_overlap (float):   overlap between consecutive clips (sec)
-        final_clip (str):       behavior if final clip is less than clip_duration
+        clip_overlap (float): overlap between consecutive clips (sec)
+        clip_overlap_fraction (float): overlap between consecutive clips as a fraction of
+            clip_duration
+        clip_step (float): step size between consecutive clips (sec)
+            - only one of clip_overlap, clip_overlap_fraction, or clip_step should be provided
+            - if all are None, defaults to clip_overlap=0
+        final_clip (str): behavior if final clip is less than clip_duration
             seconds long. By default, discards remaining audio if less than
             clip_duration seconds long [default: None].
             Options:
@@ -189,6 +197,8 @@ def ribbit(
         full_duration=spectrogram.duration,
         clip_duration=clip_duration,
         clip_overlap=clip_overlap,
+        clip_overlap_fraction=clip_overlap_fraction,
+        clip_step=clip_step,
         final_clip=final_clip,
     )
     clip_df["score"] = np.nan

--- a/opensoundscape/utils.py
+++ b/opensoundscape/utils.py
@@ -3,6 +3,7 @@
 import datetime
 import warnings
 
+from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytz
@@ -127,7 +128,9 @@ def jitter(x, width, distribution="gaussian"):
 def generate_clip_times_df(
     full_duration,
     clip_duration,
-    clip_overlap=0,
+    clip_overlap=None,
+    clip_overlap_fraction=None,
+    clip_step=None,
     final_clip=None,
     rounding_precision=10,
 ):
@@ -142,7 +145,11 @@ def generate_clip_times_df(
     Args:
         full_duration: The amount of time (seconds) to split into clips
         clip_duration (float):  The duration in seconds of the clips
-        clip_overlap (float):   The overlap of the clips in seconds [default: 0]
+        clip_overlap (float):   The overlap of the clips in seconds
+        clip_overlap_fraction (float): The overlap of the clips as a fraction of clip_duration
+        clip_step (float):      The increment in seconds between starts of consecutive clips
+            - must only specify one of clip_overlap, clip_overlap_fraction, or clip_step
+            - if all are None, overlap is set to 0
         final_clip (str):       Behavior if final_clip is less than clip_duration
             seconds long. By default, discards remaining time if less than
             clip_duration seconds long [default: None].
@@ -167,7 +174,27 @@ def generate_clip_times_df(
             f"or None. Got {final_clip}."
         )
 
-    assert clip_overlap < clip_duration, "clip_overlap must be less than clip_duration"
+    overspecified_overlap_err = (
+        "only one of clip_overlap, clip_overlap_fraction, or clip_step can be specified"
+    )
+    if clip_overlap is not None:
+        if clip_overlap_fraction is not None or clip_step is not None:
+            raise ValueError(overspecified_overlap_err)
+        assert (
+            clip_overlap < clip_duration
+        ), "clip_overlap must be less than clip_duration"
+    elif clip_overlap_fraction is not None:
+        if clip_overlap is not None or clip_step is not None:
+            raise ValueError(overspecified_overlap_err)
+        assert 0 <= clip_overlap_fraction < 1, "clip_overlap_fraction must be in [0, 1)"
+        clip_overlap = clip_overlap_fraction * clip_duration
+    elif clip_step is not None:
+        # allow values outside of [0, clip_duration]
+        if clip_overlap is not None or clip_overlap_fraction is not None:
+            raise ValueError(overspecified_overlap_err)
+        clip_overlap = clip_duration - clip_step
+    else:
+        clip_overlap = 0
 
     # Lists of start and end times for clips
     increment = clip_duration - clip_overlap
@@ -218,7 +245,9 @@ def cast_np_to_native(x):
 def make_clip_df(
     files,
     clip_duration,
-    clip_overlap=0,
+    clip_overlap=None,
+    clip_overlap_fraction=None,
+    clip_step=None,
     final_clip=None,
     return_invalid_samples=False,
     raise_exceptions=False,
@@ -243,6 +272,8 @@ def make_clip_df(
             belonging to that file in the returned clip dataframe.
         clip_duration (float): see generate_clip_times_df
         clip_overlap (float): see generate_clip_times_df
+        clip_overlap_fraction (float): see generate_clip_times_df
+        clip_step (float): see generate_clip_times_df
         final_clip (str): see generate_clip_times_df
         return_invalid_samples (bool): if True, returns additional value,
             a list of samples that caused exceptions
@@ -263,10 +294,6 @@ def make_clip_df(
         the dataframe will have one row with np.nan for 'start_time' and 'end_time' for that
         file path.
     """
-    if isinstance(files, str):
-        raise TypeError(
-            "make_clip_df expects a list of files, it looks like you passed it a string"
-        )
 
     label_df = None  # assume no labels to begin with, just a list of paths
     if isinstance(files, pd.DataFrame):
@@ -274,6 +301,8 @@ def make_clip_df(
         # use the dataframe as labels, keeping each column as a class
         # if paths are duplicated in index, keep only the first of each
         label_df = files[~files.index.duplicated(keep="first")]
+    elif isinstance(files, (str, Path)):
+        files = [files]  # be lenient, turn single path into list
     else:
         assert hasattr(files, "__iter__"), (
             f"`files` should be a dataframe with paths as "
@@ -291,6 +320,8 @@ def make_clip_df(
                 full_duration=t,
                 clip_duration=clip_duration,
                 clip_overlap=clip_overlap,
+                clip_overlap_fraction=clip_overlap_fraction,
+                clip_step=clip_step,
                 final_clip=final_clip,
             )
             clips["file"] = f

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -580,3 +580,19 @@ def test_predict_posixpath_missing_files(missing_file_df, test_df):
     assert np.all([isnan(score) for score in scores.iloc[0].values])
     assert len(invalid_samples) == 1
     assert missing_file_df.index.values[0] in invalid_samples
+
+
+def test_predict_overlap_fraction_deprecated(test_df):
+    """
+    should give deprecation error if clip_overlap_fraction is passed.
+
+    Future version will remove this argument in favor of clip_overlap_fraction
+
+    also, should raise AssertionError if both args are passed (over-specified)
+    """
+    model = cnn.CNN("resnet18", classes=[0, 1], sample_duration=5.0)
+    with pytest.warns(DeprecationWarning):
+        scores = model.predict(test_df, overlap_fraction=0.5)
+        assert len(scores) == 3
+    with pytest.raises(AssertionError):
+        model.predict(test_df, overlap_fraction=0.5, clip_overlap_fraction=0.5)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -134,6 +134,48 @@ def test_generate_clip_times_df_overlap():
     assert clip_df.iloc[1]["start_time"] == 2.5
     assert clip_df.iloc[1]["end_time"] == 7.5
 
+    clip_df = utils.generate_clip_times_df(
+        full_duration=10, clip_duration=5, clip_overlap_fraction=0.5
+    )
+    assert clip_df.shape[0] == 3
+    assert clip_df.iloc[0]["start_time"] == 0.0
+    assert clip_df.iloc[0]["end_time"] == 5.0
+    assert clip_df.iloc[1]["start_time"] == 2.5
+    assert clip_df.iloc[1]["end_time"] == 7.5
+
+    clip_df = utils.generate_clip_times_df(
+        full_duration=10, clip_duration=5, clip_step=2.5
+    )
+    assert clip_df.shape[0] == 3
+    assert clip_df.iloc[0]["start_time"] == 0.0
+    assert clip_df.iloc[0]["end_time"] == 5.0
+    assert clip_df.iloc[1]["start_time"] == 2.5
+    assert clip_df.iloc[1]["end_time"] == 7.5
+
+
+def test_generate_clip_times_df_overlap_raises_overspecified():
+    with pytest.raises(ValueError):
+        utils.generate_clip_times_df(
+            full_duration=10,
+            clip_duration=5,
+            clip_overlap=2.5,
+            clip_overlap_fraction=0.5,
+        )
+    with pytest.raises(ValueError):
+        utils.generate_clip_times_df(
+            full_duration=10,
+            clip_duration=5,
+            clip_overlap=2.5,
+            clip_step=0.5,
+        )
+    with pytest.raises(ValueError):
+        utils.generate_clip_times_df(
+            full_duration=10,
+            clip_duration=5,
+            clip_overlap_fraction=0.5,
+            clip_step=0.5,
+        )
+
 
 def test_make_clip_df(silence_10s_mp3_str):
     """many corner cases / alternatives are tested for audio.split()


### PR DESCRIPTION
add consistent and flexible specification of consecutive clip overlap throughout the code: clip step seconds, clip overlap seconds, or clip overlap fraction. Updates ribbit, CNN.predict, SafeAudioDataLoader, make_clip_df, generate_clip_times_df, AudioSplittingDataset, BoxedAnnotations.one_hot_clip_labels,  AudioFileDataset

resolves overlap_time or step_time argument for predicting on overlapping clips #876

note: there deprecates "overlap_fraction" kwarg to CNN.predict in favor of any of these: "clip_overlap", "clip_overlap_fraction", "clip_step"