### PR TITLE
use speed_of_sound attribute in methods

### DIFF
--- a/opensoundscape/localization.py
+++ b/opensoundscape/localization.py
@@ -353,6 +353,7 @@ class SpatialEvent:
             receiver_locations=locations,
             tdoas=tdoas,
             algorithm=localization_algorithm,
+            speed_of_sound=self.speed_of_sound,
         )
 
         if self.location_estimate is not None:
@@ -602,7 +603,7 @@ class SynchronizedRecorderArray:
                 Maximum absolute value of time delay estimated during cross correlation of two signals
                 For instance, 0.2 means that the maximal cross-correlation in the range of
                 delays between -0.2 to 0.2 seconds will be used to estimate the time delay.
-                if None (default), the max delay is set to max_receiver_dist / SPEED_OF_SOUND
+                if None (default), the max delay is set to max_receiver_dist / self.speed_of_sound
             min_n_receivers : int
                 Minimum number of receivers that must detect an event for it to be localized
                 [default: 3]
@@ -781,7 +782,7 @@ class SynchronizedRecorderArray:
             bandpass_ranges: dictionary of form {"class name": [low_f, high_f]} for audio bandpass filtering during
 
             max_delay: the maximum delay (in seconds) to consider between receivers for a single event
-                if None, defaults to max_receiver_dist / SPEED_OF_SOUND
+                if None, defaults to max_receiver_dist / self.speed_of_sound
         Returns:
             a list of SpatialEvent objects to attempt to localize
         """
@@ -923,6 +924,7 @@ class SynchronizedRecorderArray:
                                 duration=duration,
                                 class_name=cls_i,
                                 cc_filter=cc_filter,
+                                speed_of_sound=self.speed_of_sound,
                             )
                         )
 
@@ -1031,7 +1033,7 @@ def travel_time(source, receiver, speed_of_sound):
     return distance / speed_of_sound
 
 
-def localize(receiver_locations, tdoas, algorithm, speed_of_sound=SPEED_OF_SOUND):
+def localize(receiver_locations, tdoas, algorithm, speed_of_sound):
     """
     Perform TDOA localization on a sound event. If there are not enough receivers to localize the event, return None.
     Args:
@@ -1066,9 +1068,7 @@ def localize(receiver_locations, tdoas, algorithm, speed_of_sound=SPEED_OF_SOUND
     return estimate
 
 
-def least_squares_localize(
-    receiver_locations, arrival_times, speed_of_sound=SPEED_OF_SOUND
-):
+def least_squares_localize(receiver_locations, arrival_times, speed_of_sound):
     """
     Use a least squares optimizer to perform TDOA localization on a sound event, based on a set of TDOA times and receiver locations.
     Args:
@@ -1122,7 +1122,7 @@ def least_squares_localize(
 def soundfinder_localize(
     receiver_locations,
     arrival_times,
-    speed_of_sound=SPEED_OF_SOUND,
+    speed_of_sound,
     invert_alg="gps",  # options: 'gps'
     center=True,  # True for original Sound Finder behavior
     pseudo=True,  # False for original Sound Finder
@@ -1304,7 +1304,7 @@ def soundfinder_localize(
             return u1[0:-1]
 
 
-def gillette_localize(receiver_locations, arrival_times, speed_of_sound=SPEED_OF_SOUND):
+def gillette_localize(receiver_locations, arrival_times, speed_of_sound):
     """
     Uses the Gillette and Silverman [1] localization algorithm to localize a sound event from a set of TDOAs.
     Args:

--- a/poetry.lock
+++ b/poetry.lock
@@ -6093,4 +6093,4 @@ tensorflow = []
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "960ee8e5604a307c2460aafbcf65f021332dd330d79117468109261def4e6d6b"
+content-hash = "6f07509a5e4d9c276dca4bc3b9f016032530ec37e260ec87091ffaaef6b51e12"

--- a/tests/test_localization.py
+++ b/tests/test_localization.py
@@ -110,6 +110,7 @@ def test_soundfinder_localize_2d():
     estimate = localization.soundfinder_localize(
         reciever_locations,
         arrival_times,
+        speed_of_sound=343,
     )
     assert close(np.linalg.norm(np.array(estimate[0:2]) - np.array([10, 10])), 0, 0.01)
 
@@ -120,6 +121,7 @@ def test_soundfinder_3d():
     estimate = localization.soundfinder_localize(
         reciever_locations,
         arrival_times,
+        speed_of_sound=343,
     )
     assert close(
         np.linalg.norm(np.array(estimate[0:3]) - np.array([10, 10, 0])), 0, 0.1
@@ -132,7 +134,7 @@ def test_soundfinder_lstsq():
     arrival_times = [1, 1, 1, 1]
     with pytest.raises(NotImplementedError):
         estimate = localization.soundfinder_localize(
-            reciever_locations, arrival_times, invert_alg="lstsq"
+            reciever_locations, arrival_times, invert_alg="lstsq", speed_of_sound=343
         )
     # assert close(
     #     np.linalg.norm(np.array(estimate[0:3]) - np.array([10, 10, 0])), 0, 0.1
@@ -146,6 +148,7 @@ def test_soundfinder_nocenter():
         reciever_locations,
         arrival_times,
         center=False,  # True for original Sound Finder behavior
+        speed_of_sound=343,
     )
     assert close(
         np.linalg.norm(np.array(estimate[0:3]) - np.array([110, 10, 0])), 0, 0.1
@@ -158,7 +161,9 @@ def test_gillette_localize_raises():
 
     # check this raises a ValueError because none of the arrival times are zero
     with pytest.raises(ValueError):
-        localization.gillette_localize(reciever_locations, arrival_times)
+        localization.gillette_localize(
+            reciever_locations, arrival_times, speed_of_sound=343
+        )
 
 
 def test_gillette_localize_2d():
@@ -171,7 +176,9 @@ def test_gillette_localize_2d():
     )
     tdoas = time_of_flight - np.min(time_of_flight)
 
-    estimated_pos = localization.gillette_localize(receiver_locations, tdoas)
+    estimated_pos = localization.gillette_localize(
+        receiver_locations, tdoas, speed_of_sound=speed_of_sound
+    )
 
     assert np.allclose(estimated_pos, sound_source, rtol=0.1)
 
@@ -190,7 +197,9 @@ def test_gillette_localize_3d():
     for ref_index in range(len(time_of_flight)):
         tdoas = time_of_flight - time_of_flight[ref_index]
 
-        estimated_pos = localization.gillette_localize(receiver_locations, tdoas)
+        estimated_pos = localization.gillette_localize(
+            receiver_locations, tdoas, speed_of_sound=speed_of_sound
+        )
 
         assert np.allclose(estimated_pos, sound_source, atol=2.5)
 
@@ -204,6 +213,7 @@ def test_soundfinder_nopseudo():
         invert_alg="gps",  # options: 'lstsq', 'gps'
         center=True,  # True for original Sound Finder behavior
         pseudo=False,  # False for original Sound Finder
+        speed_of_sound=343,
     )
     assert close(
         np.linalg.norm(np.array(estimate[0:3]) - np.array([10, 10, 0])), 0, 0.1
@@ -224,7 +234,9 @@ def test_least_squares_optimize():
     for ref_index in range(len(time_of_flight)):
         tdoas = time_of_flight - time_of_flight[ref_index]
 
-        estimated_pos = localization.least_squares_localize(receiver_locations, tdoas)
+        estimated_pos = localization.least_squares_localize(
+            receiver_locations, tdoas, speed_of_sound=speed_of_sound
+        )
 
         assert np.allclose(estimated_pos, sound_source, atol=2.5)
 


### PR DESCRIPTION
the SpatialEvent._localize_after_cross_correlation and SyncrhonizedRecorderArray.create_candidate_events methods were not using the objects' speed_of_sound attribute.

I also removed the default speed_of_sound value for methods, only retaining it as a default for initializing the two classes.

Now I think it's sensible to retain the global variable SPEED_OF_SOUND, which provides a default value for the initialization of these two classes. Otherwise we would just be hard-coding that default (in multiple places) or not having a default.

speed_of_sound is now a required argument for localize() and the associated functions specific to each algorithm

resolves Make SPEED_OF_SOUND a class attribute instead of module/global variable #725