### PR TITLE
implement audio_root argument

### DIFF
--- a/opensoundscape/ml/datasets.py
+++ b/opensoundscape/ml/datasets.py
@@ -41,6 +41,9 @@ class AudioFileDataset(torch.utils.data.Dataset):
         preprocessor:
             an object of BasePreprocessor or its children which defines
             the operations to perform on input samples
+        audio_root:
+            optionally pass a root directory (pathlib.Path or str) to prepended to each file path
+            - if None (default), samples must contain full paths to files
 
     Returns:
         sample (AudioSample object)
@@ -53,10 +56,18 @@ class AudioFileDataset(torch.utils.data.Dataset):
             produce a list of clips with start/end times, if split_files_into_clips=True
     """
 
-    def __init__(self, samples, preprocessor, bypass_augmentations=False):
+    def __init__(
+        self, samples, preprocessor, bypass_augmentations=False, audio_root=None
+    ):
+        super().__init__()
+
         ## Input Validation ##
 
-        # validate type of samples: list, np array, or df
+        # check that audio_root argument is valid
+        msg = f"audio_root must be str, Path, or None. Got {type(audio_root)}"
+        assert isinstance(audio_root, (str, Path, type(None))), msg
+
+        # validate type of samples: list or np array of files, or df
         assert type(samples) in (
             list,
             np.ndarray,
@@ -83,6 +94,8 @@ class AudioFileDataset(torch.utils.data.Dataset):
         # give helpful warnings for incorret df, but don't raise Exception
         if len(df) > 0:
             first_path = df.index[0][0] if self.has_clips else df.index[0]
+            if audio_root is not None:
+                first_path = Path(audio_root) / first_path
             if not Path(first_path).exists():
                 warnings.warn(
                     "Index of dataframe passed to "
@@ -95,12 +108,22 @@ class AudioFileDataset(torch.utils.data.Dataset):
             warnings.warn("Zero samples!")
 
         self.classes = df.columns
-        self.label_df = df
-        self.preprocessor = preprocessor
-        self.invalid_samples = set()
+        """list of classes to which multi-hot labels correspond"""
 
-        # if True skips Actions with .is_augmentation=True
+        self.label_df = df
+        """dataframe containing file paths, clip times, and multi-hot labels (one column per class)"""
+
+        self.preprocessor = preprocessor
+        """Preprocessor object containing a .pipeline of ordered preprocessing operations"""
+
+        self.invalid_samples = set()
+        """set of file paths that raised exceptions during preprocessing"""
+
+        self.audio_root = audio_root
+        """path to prepend to all audio file paths when loading"""
+
         self.bypass_augmentations = bypass_augmentations
+        """if True, skips Actions with .is_augmentation=True"""
 
     @classmethod
     def from_categorical_df(
@@ -147,10 +170,12 @@ class AudioFileDataset(torch.utils.data.Dataset):
             raise InvalidIndexError(
                 f"idx must be an integer, got {type(idx)}. "
                 f"This could happen if you specified a custom sampler that results in returning "
-                "lists of indices rather than a single index. AudioFiledataset.__getitem__ "
+                "lists of indices rather than a single index. AudioFileDataset.__getitem__ "
                 "requires that idx is a single integer index."
             )
-        sample = AudioSample.from_series(self.label_df.iloc[idx])
+        sample = AudioSample.from_series(
+            self.label_df.iloc[idx], audio_root=self.audio_root
+        )
 
         # preprocessor.forward will raise PreprocessingError if something fails
         sample = self.preprocessor.forward(
@@ -218,8 +243,20 @@ class AudioSplittingDataset(AudioFileDataset):
         **kwargs are passed to opensoundscape.utils.make_clip_df
     """
 
-    def __init__(self, samples, preprocessor, **kwargs):
-        super().__init__(samples=samples, preprocessor=preprocessor)
+    def __init__(
+        self,
+        samples,
+        preprocessor,
+        bypass_augmentations=False,
+        audio_root=None,
+        **kwargs,
+    ):
+        super().__init__(
+            samples=samples,
+            preprocessor=preprocessor,
+            bypass_augmentations=bypass_augmentations,
+            audio_root=audio_root,
+        )
 
         self.has_clips = True
 
@@ -230,5 +267,6 @@ class AudioSplittingDataset(AudioFileDataset):
             files=samples,
             clip_duration=preprocessor.sample_duration,
             return_invalid_samples=True,
+            audio_root=audio_root,
             **kwargs,
         )

--- a/opensoundscape/preprocess/actions.py
+++ b/opensoundscape/preprocess/actions.py
@@ -281,8 +281,8 @@ class AudioClipLoader(Action):
     """Action to load clips from an audio file
 
     Loads an audio file or part of a file to an Audio object.
-    Will load entire audio file if _start_time and _end_time are None.
-    If _start_time and _end_time are provided, loads the audio only in the
+    Will load entire audio file if sample.start_time and sample.duration are None.
+    If sample.start_time and sample.duration are provided, loads the audio only in the
     specified interval.
 
     see Audio.from_file() for documentation.
@@ -300,7 +300,7 @@ class AudioClipLoader(Action):
 
     def __call__(self, sample, **kwargs):
         offset = 0 if sample.start_time is None else sample.start_time
-        duration = None if sample.duration is None else sample.duration
+        duration = sample.duration
         sample.data = self.action_fn(
             sample.data, offset=offset, duration=duration, **dict(self.params, **kwargs)
         )

--- a/opensoundscape/preprocess/preprocessors.py
+++ b/opensoundscape/preprocess/preprocessors.py
@@ -76,7 +76,6 @@ class BasePreprocessor:
     in the pipeline to produce a sample.
 
     Args:
-        action_dict: dictionary of name:Action actions to perform sequentially
         sample_duration: length of audio samples to generate (seconds)
     """
 

--- a/opensoundscape/utils.py
+++ b/opensoundscape/utils.py
@@ -251,6 +251,7 @@ def make_clip_df(
     final_clip=None,
     return_invalid_samples=False,
     raise_exceptions=False,
+    audio_root=None,
 ):
     """generate df of fixed-length clip start/end times for a set of files
 
@@ -281,6 +282,9 @@ def make_clip_df(
             to check the duration of an audio file, the exception will be raised.
             If False [default], adds a row to the dataframe with np.nan for
             'start_time' and 'end_time' for that file path.
+        audio_root: optionally pass a root directory (pathlib.Path or str)
+            - `audio_root` is prepended to each file path
+            - if None (default), `files` must contain full paths to files
 
     Returns:
         clip_df: dataframe multi-index ('file','start_time','end_time')
@@ -314,8 +318,12 @@ def make_clip_df(
     invalid_samples = set()
     idx_cols = ["file", "start_time", "end_time"]
     for f in file_list:
+        if audio_root is None:
+            path = f
+        else:
+            path = Path(audio_root) / Path(f)
         try:
-            t = librosa.get_duration(path=f)
+            t = librosa.get_duration(path=path)
             clips = generate_clip_times_df(
                 full_duration=t,
                 clip_duration=clip_duration,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -26,6 +26,13 @@ def short_file_df():
 
 
 @pytest.fixture()
+def relative_path_df():
+    paths = ["audio/veryshort.wav"]
+    labels = [[0, 1]]
+    return pd.DataFrame(index=paths, data=labels, columns=[0, 1])
+
+
+@pytest.fixture()
 def bad_good_df():
     paths = ["tests/audio/veryshort.wav", "tests/audio/silence_10s.mp3"]
     labels = [[1, 0], [1, 0]]
@@ -74,6 +81,17 @@ def test_audio_file_dataset(dataset_df, pre):
     pre.width = 224
     pre.channels = 3
     dataset = AudioFileDataset(dataset_df, pre)
+    sample1 = dataset[0]
+    assert sample1.data.numpy().shape == (3, 224, 224)
+    assert dataset[0].labels.values.shape == (2,)
+
+
+def test_audio_root(relative_path_df, pre):
+    pre.bypass_augmentation = True
+    pre.height = 224
+    pre.width = 224
+    pre.channels = 3
+    dataset = AudioFileDataset(relative_path_df, pre, audio_root="tests/")
     sample1 = dataset[0]
     assert sample1.data.numpy().shape == (3, 224, 224)
     assert dataset[0].labels.values.shape == (2,)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -192,6 +192,21 @@ def test_make_clip_df(silence_10s_mp3_str):
     assert len(invalid_samples) == 1
 
 
+def test_make_clip_df_audio_root():
+    """many corner cases / alternatives are tested for audio.split()
+
+    by default, notafile.wav makes 1 row with nan as start_time and end_time
+    (controlled by raise_exceptions argument)
+    """
+    clip_df, invalid_samples = utils.make_clip_df(
+        files=["silence_10s.mp3"],
+        clip_duration=5.0,
+        return_invalid_samples=True,
+        audio_root="tests/audio/",
+    )
+    assert len(clip_df) == 2
+
+
 def test_make_clip_df_raise(silence_10s_mp3_str):
     """many corner cases / alternatives are tested for audio.split()"""
     with pytest.raises(utils.GetDurationError):


### PR DESCRIPTION
allows  train_df/val_df/samples dataframes to contain relative paths during training and inference

includes tests for predict() and train()