### PR TITLE
Pad TDOA windows so detections at file start/end can be localized

### DIFF
--- a/opensoundscape/audio.py
+++ b/opensoundscape/audio.py
@@ -1906,6 +1906,96 @@ def clipping_detector(samples, threshold=0.6):
     return len(list(filter(lambda x: x > threshold, samples)))
 
 
+def load_padded_audio_window(path, offset, duration, min_real_duration=0, **kwargs):
+    """Load a time window, padding with silence if it extends past the file.
+
+    Used by localization to extract `duration` seconds starting at `offset`,
+    even when that window begins before the start of the file or ends after
+    the file. Missing samples are replaced with zeros on the side that is
+    out of bounds.
+
+    Returns None if the file has no overlapping samples, or if the overlapping
+    real audio is shorter than `min_real_duration`. Completely missing audio is
+    not padded into a silent clip.
+
+    Args:
+        path: audio file path
+        offset: start of the requested window in seconds, relative to file start.
+            May be negative (requesting audio before the file begins).
+        duration: length of the requested window in seconds
+        min_real_duration: if the overlapping real audio is shorter than this
+            (seconds), return None instead of a padded clip. Default 0 returns
+            None only when there is no overlap.
+        **kwargs: passed to Audio.from_file (e.g. sample_rate). `offset`,
+            `duration`, and `out_of_bounds_mode` are set by this function.
+
+    Returns:
+        Audio of length `duration`, or None if the window should be discarded
+    """
+    if duration is None or duration <= 0:
+        raise ValueError(f"`duration` must be > 0, got {duration}")
+
+    offset = float(offset)
+    duration = float(duration)
+    pre_pad = max(0.0, -offset)
+    load_offset = max(0.0, offset)
+    load_duration = duration - pre_pad
+
+    if load_duration <= 0:
+        return None
+
+    try:
+        file_duration = soundfile.info(str(path)).duration
+    except Exception:
+        file_duration = None
+
+    # seeking past EOF raises in librosa/soundfile; treat as no overlap.
+    # do not clamp duration: from_file(out_of_bounds_mode="ignore") already
+    # returns the available samples when the window extends past EOF.
+    if file_duration is not None and load_offset >= file_duration:
+        return None
+
+    audio = Audio.from_file(
+        path,
+        offset=load_offset,
+        duration=load_duration,
+        out_of_bounds_mode="ignore",
+        **kwargs,
+    )
+    n_real = len(audio.samples)
+    if n_real == 0:
+        return None
+
+    sample_rate = audio.sample_rate
+    if n_real / sample_rate < min_real_duration - 1e-3:
+        return None
+
+    target_n = int(round(duration * sample_rate))
+    n_pre = int(round(pre_pad * sample_rate))
+    max_content = max(target_n - n_pre, 0)
+    if n_real > max_content:
+        audio = audio.trim_samples(0, max_content)
+        n_real = len(audio.samples)
+
+    n_post = max(target_n - n_pre - n_real, 0)
+    if n_pre > 0 or n_post > 0:
+        audio = audio.pad(
+            pre_duration=n_pre / sample_rate,
+            post_duration=n_post / sample_rate,
+        )
+
+    samples = audio.samples
+    if len(samples) < target_n:
+        samples = np.pad(samples, (0, target_n - len(samples)))
+    elif len(samples) > target_n:
+        samples = samples[:target_n]
+
+    metadata = None if audio.metadata is None else audio.metadata.copy()
+    if metadata is not None:
+        metadata["duration"] = target_n / sample_rate
+    return audio._spawn(samples=samples, metadata=metadata)
+
+
 def _audio_from_file_handler(
     cls,
     path,

--- a/opensoundscape/localization/position_estimate.py
+++ b/opensoundscape/localization/position_estimate.py
@@ -111,19 +111,25 @@ class PositionEstimate:
         plt.pcolormesh(np.vstack([s.spectrogram for s in specs]),cmap='Greys')
         ```
         """
-        from opensoundscape.audio import Audio
+        from opensoundscape.audio import Audio, load_padded_audio_window
 
+        duration = self.duration + start_offset + end_offset
         all_audio = []
         for i, audio_path in enumerate(self.receiver_files):
             start = self.receiver_start_time_offsets[i] + self.tdoas[i] - start_offset
-            all_audio.append(
-                Audio.from_file(
-                    audio_path,
-                    offset=start,
-                    duration=self.duration + start_offset + end_offset,
-                    out_of_bounds_mode="warn",
-                )
+            clip = load_padded_audio_window(
+                audio_path,
+                offset=start,
+                duration=duration,
             )
+            if clip is None:
+                # no overlap with the file; return silence matching requested duration
+                probe = Audio.from_file(
+                    audio_path, duration=0.0001, out_of_bounds_mode="ignore"
+                )
+                sample_rate = probe.sample_rate if len(probe.samples) else 22050
+                clip = Audio.silence(duration=duration, sample_rate=sample_rate)
+            all_audio.append(clip)
 
         return all_audio
 

--- a/opensoundscape/localization/spatial_event.py
+++ b/opensoundscape/localization/spatial_event.py
@@ -3,7 +3,7 @@ import numpy as np
 import datetime
 import pandas as pd
 
-from opensoundscape.audio import Audio
+from opensoundscape.audio import load_padded_audio_window
 from opensoundscape import audio
 from opensoundscape.utils import cast_np_to_native
 from opensoundscape.localization.localization_algorithms import SPEED_OF_SOUND
@@ -223,6 +223,11 @@ class SpatialEvent:
             value corresponds to the cross correlation of one file relative
             to the first file (self.receiver_files[0])
 
+            If a requested window extends before the start or after the end of a
+            file, the missing samples are padded with silence so TDOA can still
+            run. Receivers whose files do not contain the detection itself are
+            discarded.
+
         Effects:
             sets self.tdoas and self.cc_maxs with the same values as those returned
         """
@@ -236,18 +241,17 @@ class SpatialEvent:
             # sets the .receiver_start_time_offsets using start_timestamp and receiver start times
             self._calculate_receiver_start_time_offsets()
 
-        # load audio from desired time period
-        reference_audio = Audio.from_file(
+        # load audio from desired time period, padding with silence if the
+        # window extends before the start or after the end of the file
+        reference_audio = load_padded_audio_window(
             self.receiver_files[0],
             offset=self.receiver_start_time_offsets[0] - self.max_delay,
             duration=extracted_clip_duration,
+            min_real_duration=self.duration,
         )
 
-        # make sure the audio clip is of the desired length
-        # Note: this will give errors for clips starting at 0s since we can't get earlier audio;
-        # alternatively, we could pad the audio with zeros
-        if not np.isclose(reference_audio.duration, extracted_clip_duration, atol=1e-3):
-            # don't try to localize
+        # skip localization if the reference file does not contain the detection
+        if reference_audio is None:
             self.error_msg = "did not get audio clip of desired length"
             self.tdoas = None
             self.cc_maxs = None
@@ -259,7 +263,7 @@ class SpatialEvent:
         cc_maxs = []
 
         # catch the receivers that have an issue and should be discarded
-        # e.g. their file starts or end during the time-window, so estimate_delays is not possible
+        # e.g. the file does not contain the detection window
         bad_receivers_index = []
 
         for index, file in enumerate(self.receiver_files):
@@ -269,15 +273,19 @@ class SpatialEvent:
                 continue
 
             # use specified time offsets to extract the correct audio segment
-            audio2 = Audio.from_file(
+            audio2 = load_padded_audio_window(
                 file,
                 offset=self.receiver_start_time_offsets[index] - self.max_delay,
                 duration=extracted_clip_duration,
+                min_real_duration=self.duration,
             )
 
-            # catch edge cases where the audio lengths do not match.
-            # allow for 1 sample difference
-            if abs(len(audio2.samples) - len(reference_audio.samples)) > 1:
+            # discard receivers with no usable audio or a residual length mismatch
+            # (allow 1 sample difference for rounding)
+            if (
+                audio2 is None
+                or abs(len(audio2.samples) - len(reference_audio.samples)) > 1
+            ):
                 bad_receivers_index.append(index)
             else:
                 tdoa, cc_max = audio.estimate_delay(
@@ -298,7 +306,7 @@ class SpatialEvent:
         # i.e. those that had audio length mismatches
         if len(bad_receivers_index) > 0:
             print(
-                f"Warning: {len(bad_receivers_index)} receivers were discarded because their audio files were not the same length as the primary receiver."
+                f"Warning: {len(bad_receivers_index)} receivers were discarded because they did not contain the detection window."
             )
             # drop the bad receivers from the list of files and locations
             self.receiver_files = np.array(

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -9,7 +9,12 @@ import pytz
 import datetime
 import pandas as pd
 
-from opensoundscape.audio import Audio, AudioOutOfBoundsError, load_channels_as_audio
+from opensoundscape.audio import (
+    Audio,
+    AudioOutOfBoundsError,
+    load_channels_as_audio,
+    load_padded_audio_window,
+)
 from opensoundscape import audio
 import opensoundscape
 
@@ -1374,3 +1379,51 @@ def test_pad_to(veryshort_wav_audio):
         veryshort_wav_audio.samples,
         atol=1e-7,
     )
+
+
+def test_load_padded_audio_window_before_start():
+    path = "tests/audio/LOCA_2021_09_24_652_3.wav"  # 1.0s file
+    pre_pad = 0.1
+    duration = 0.5
+    audio = load_padded_audio_window(path, offset=-pre_pad, duration=duration)
+    assert audio is not None
+    assert math.isclose(audio.duration, duration, abs_tol=1e-4)
+    n_pre = int(round(pre_pad * audio.sample_rate))
+    assert math.isclose(0.0, np.max(np.abs(audio.samples[:n_pre])), abs_tol=1e-7)
+    original = Audio.from_file(path, offset=0, duration=duration - pre_pad)
+    assert np.allclose(
+        audio.samples[n_pre : n_pre + len(original.samples)], original.samples
+    )
+
+
+def test_load_padded_audio_window_after_end():
+    path = "tests/audio/LOCA_2021_09_24_652_3.wav"  # 1.0s file
+    offset = 0.8
+    duration = 0.5  # extends 0.3s past EOF
+    audio = load_padded_audio_window(path, offset=offset, duration=duration)
+    assert audio is not None
+    assert math.isclose(audio.duration, duration, abs_tol=1e-4)
+    original = Audio.from_file(
+        path, offset=offset, duration=duration, out_of_bounds_mode="ignore"
+    )
+    n_real = len(original.samples)
+    assert np.allclose(audio.samples[:n_real], original.samples)
+    assert math.isclose(0.0, np.max(np.abs(audio.samples[n_real:])), abs_tol=1e-7)
+
+
+def test_load_padded_audio_window_no_overlap_returns_none():
+    path = "tests/audio/LOCA_2021_09_24_652_3.wav"  # 1.0s file
+    assert load_padded_audio_window(path, offset=1.5, duration=0.5) is None
+
+
+def test_load_padded_audio_window_min_real_duration():
+    path = "tests/audio/veryshort.wav"  # ~0.14s
+    # window overlaps the file but real audio is shorter than the detection
+    audio = load_padded_audio_window(
+        path, offset=-0.04, duration=0.38, min_real_duration=0.3
+    )
+    assert audio is None
+    # without the minimum, the overlapping audio is padded and returned
+    padded = load_padded_audio_window(path, offset=-0.04, duration=0.38)
+    assert padded is not None
+    assert math.isclose(padded.duration, 0.38, abs_tol=1e-4)

--- a/tests/test_localization.py
+++ b/tests/test_localization.py
@@ -285,15 +285,14 @@ def test_localization_pipeline(file_coords_csv, predictions):
         assert math.isclose(position.location_estimate[1], true_y, abs_tol=2)
 
     # test load_audio_segments, loading with 1s before and after the event start/end
-
-    with pytest.warns(UserWarning):  # warning for extending beyond edges of audio
-        audio_list = position_estimates[0].load_aligned_audio_segments(
-            start_offset=1, end_offset=1
-        )
+    # clips that extend past the file are padded with silence
+    audio_list = position_estimates[0].load_aligned_audio_segments(
+        start_offset=1, end_offset=1
+    )
     assert len(audio_list) == 5
-    # event is 1s long, so we should have 3s total (slightly less for others
-    # due to tdoa offsets and extending beyond file edges)
-    assert np.isclose(audio_list[0].duration, 3, atol=1e-5)
+    # event is 1s long, so we should have 3s total on every receiver
+    for a in audio_list:
+        assert np.isclose(a.duration, 3, atol=1e-5)
 
 
 def test_localization_pipeline_real_audio(LOCA_2021_aru_coords, LOCA_2021_detections):
@@ -403,6 +402,58 @@ def test_SpatialEvent_estimate_delays(LOCA_2021_aru_coords):
     assert all(
         success.values()
     ), f"Incorrect result for cc_filters: {[k for k,v in success.items() if not v]}"
+
+
+def _loca_receiver_subset(LOCA_2021_aru_coords):
+    files = [
+        f
+        for f in LOCA_2021_aru_coords.index
+        if "LOCA_2021_09_24_652_" in f and "late" not in f
+    ]
+    return files, LOCA_2021_aru_coords.loc[files]
+
+
+def test_estimate_delays_at_file_start(LOCA_2021_aru_coords):
+    """Detections at t=0 should be padded and still produce TDOAs (issue #1278)"""
+    files, coords = _loca_receiver_subset(LOCA_2021_aru_coords)
+    event = localization.SpatialEvent(
+        receiver_files=files,
+        receiver_locations=coords.values,
+        max_delay=0.04,
+        receiver_start_time_offsets=[0.0] * len(files),
+        duration=0.3,
+        class_name="zeep",
+        bandpass_range=(7000, 10000),
+        cc_filter="phat",
+    )
+    tdoas, cc_maxs = event._estimate_delays()
+    assert tdoas is not None
+    assert cc_maxs is not None
+    assert len(tdoas) == len(files)
+    assert tdoas[0] == 0
+
+
+def test_estimate_delays_at_file_end(LOCA_2021_aru_coords):
+    """Detections at the end of 1s files should be padded and still produce TDOAs (issue #1278)"""
+    files, coords = _loca_receiver_subset(LOCA_2021_aru_coords)
+    duration = 0.3
+    # LOCA files are 1.0s; start at 0.7 so the detection ends at EOF and the
+    # max_delay buffer extends past the file
+    event = localization.SpatialEvent(
+        receiver_files=files,
+        receiver_locations=coords.values,
+        max_delay=0.04,
+        receiver_start_time_offsets=[0.7] * len(files),
+        duration=duration,
+        class_name="zeep",
+        bandpass_range=(7000, 10000),
+        cc_filter="phat",
+    )
+    tdoas, cc_maxs = event._estimate_delays()
+    assert tdoas is not None
+    assert cc_maxs is not None
+    assert len(tdoas) == len(files)
+    assert tdoas[0] == 0
 
 
 def test_spatial_event_receiver_removal_and_cc_threshold(LOCA_2021_aru_coords):


### PR DESCRIPTION
## Summary
- Localization no longer skips events whose TDOA window extends before the start or after the end of a file. Missing buffer samples are padded with silence, and GCC/TDOA still runs.
- Receivers that do not actually contain the detection (empty overlap or shorter than the detection duration) are still dropped.
- `load_aligned_audio_segments` uses the same padding so aligned clips have the requested duration.

Fixes #1278.

## Test plan
- [x] `pytest tests/test_localization.py tests/test_audio.py -k 'pad or localization or estimate_delays'` (41 localization tests + pad helper tests passed locally)
- [ ] Confirm a detection at `start_time=0` is localized rather than returning `tdoas=None`
- [ ] Confirm a detection whose window runs past EOF is localized
- [ ] Confirm a file that does not contain the detection (e.g. `veryshort.wav`) is still discarded

Made with [Cursor](https://cursor.com)